### PR TITLE
Update to Dotty 0.17.0-RC1

### DIFF
--- a/eec/build.sbt
+++ b/eec/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.16.0-RC3"
+val dottyVersion = "0.17.0-RC1"
 // val dottyVersion = dottyLatestNightlyBuild.get
 
 enablePlugins(Antlr4Plugin)

--- a/eec/src/test/scala/eec/compiler/types/ExprTest.scala
+++ b/eec/src/test/scala/eec/compiler/types/ExprTest.scala
@@ -2,6 +2,8 @@ package eec.compiler.types
 
 import ExprBootstraps._
 
+import org.junit.{ Test => test }
+
 class ExprTest {
 
   @test def typecheckInteger() = typecheck(

--- a/eec/src/test/scala/eec/compiler/types/StatTest.scala
+++ b/eec/src/test/scala/eec/compiler/types/StatTest.scala
@@ -1,6 +1,7 @@
 package eec.compiler.types
 
 import StatBootstraps._
+import org.junit.{ Test => test }
 
 class StatTest {
 

--- a/eec/src/test/scala/eec/compiler/types/bootstraps.scala
+++ b/eec/src/test/scala/eec/compiler/types/bootstraps.scala
@@ -23,8 +23,6 @@ import delegate TreeOps._
 import delegate TypeOps._
 import delegate NameOps._
 
-export org.junit.{Test => test}
-
 val any = WildcardType
 
 def (str: String) -|: (other: String) = other -> str


### PR DESCRIPTION
also refactors redundant TypeVariableOps