### PR TITLE
Add pure EEC interpreter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Run tasty tests
+    - name: Run Mesa tests
       run: sbt ";test;eec-core/test"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.21.0-RC1"
+val dottyVersion = "0.22.0-RC1"
 // val dottyVersion = dottyLatestNightlyBuild.get
 
 lazy val commonSettings = Seq(

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -15,12 +15,10 @@ object Kernel:
   enum Continuation:
     case Apply(e: Environment, arg: ErasedTree)
     case Evaluate(e: Environment, arg: ErasedTree)
-    case Pi(e: Environment, i: Int)
+    case Pi(i: Int)
     case Sigma(e: Environment, inl: Name, l: ErasedTree, inr: Name, r: ErasedTree)
-    case Bind(e: Environment, x: Name, u: ErasedTree)
-    case Reduce(e: Environment, x: Name, u: ErasedTree)
+    case Effect(e: Environment, x: Name, u: ErasedTree)
     case UnZip(e: Environment, x: Name, y: Name, u: ErasedTree)
-    case ReduceLeft(e: Environment, x: Name, y: Name, yVal: ErasedTree, u: ErasedTree)
 
   given Show[Continuation] = { case p: Product => p.productPrefix.toLowerCase }
 
@@ -37,32 +35,30 @@ object Kernel:
   private extension on (s: State):
 
     def betaReduce: State = (s: @unchecked) match
-      case ( Pair(x,_),   _, Pi(e,0)               :: ks ) => ( x, e, ks )
-      case ( Pair(_,y),   _, Pi(e,1)               :: ks ) => ( y, e, ks )
-      case ( Inl(t),      _, Sigma(e,l,u,_,_)      :: ks ) => ( u, bind(e,l->t), ks )
-      case ( Inr(t),      _, Sigma(e,_,_,r,u)      :: ks ) => ( u, bind(e,r->t), ks )
-      case ( t,           _, Reduce(e,x,u)         :: ks ) => ( u, bind(e,x->t), ks )
-      case ( t,           _, ReduceLeft(e,x,y,s,u) :: ks ) => ( u, bind(e,x->t,y->s), ks )
-      case ( t @ Lazy(_), _, Bind(e,x,u)           :: ks ) => ( u, bind(e,x->t.compute), ks )
-      case ( Bang(t),     e, Bind(f,x,u)           :: ks ) => ( t, e, Reduce(f,x,u)::ks )
-      case ( Tensor(t,s), e, UnZip(f,x,y,u)        :: ks ) => ( t, e, ReduceLeft(f,x,y,s,u)::ks )
-      case ( Lam(x,t),    e, Apply(f,m)            :: ks ) => ( t, Closure(x,m,f)::e, ks )
-      case ( Lin(x,t),    e, Evaluate(f,m)         :: ks ) => ( t, Closure(x,m,f)::e, ks )
-      case ( err,         _, (_: Pi)               :: ks ) => typeError(s"expected (_,_) but got: ${err.show}")
-      case ( err,         _, (_: Sigma)            :: ks ) => typeError(s"expected (inl _) or (inr _) but got: ${err.show}")
-      case ( err,         _, (_: Bind)             :: ks ) => typeError(s"expected (!_) but got: ${err.show}")
-      case ( err,         _, (_: UnZip)            :: ks ) => typeError(s"expected (!_*:_) but got: ${err.show}")
-      case ( err,         _, (_: Apply)            :: ks ) => typeError(s"expected (\\_._) but got ${err.show}")
-      case ( err,         _, (_: Evaluate)         :: ks ) => typeError(s"expected (^\\_._) but got ${err.show}")
+      case ( Pair(x,_),   e, Pi(0)            :: ks ) => ( x, e,                      ks )
+      case ( Pair(_,y),   e, Pi(1)            :: ks ) => ( y, e,                      ks )
+      case ( Inl(t),      e, Sigma(f,l,u,_,_) :: ks ) => ( u, bind(f,e,l->t),         ks )
+      case ( Inr(t),      e, Sigma(f,_,_,r,u) :: ks ) => ( u, bind(f,e,r->t),         ks )
+      case ( t @ Lazy(_), e, Effect(f,x,u)    :: ks ) => ( u, bind(f,e,x->t.compute), ks )
+      case ( Bang(t),     e, Effect(f,x,u)    :: ks ) => ( u, bind(f,e,x->t),         ks )
+      case ( Tensor(t,s), e, UnZip(f,x,y,u)   :: ks ) => ( u, bind(f,e,x->t,y->s),    ks )
+      case ( Lam(x,t),    e, Apply(f,m)       :: ks ) => ( t, bind(e,f,x->m),         ks )
+      case ( Lin(x,t),    e, Evaluate(f,m)    :: ks ) => ( t, bind(e,f,x->m),         ks )
+      case ( err,         _, (_: Pi)          :: _  ) => typeError(s"expected (_,_) but got: ${err.show}")
+      case ( err,         _, (_: Sigma)       :: _  ) => typeError(s"expected (inl _) or (inr _) but got: ${err.show}")
+      case ( err,         _, (_: Effect)      :: _  ) => typeError(s"expected (!_) but got: ${err.show}")
+      case ( err,         _, (_: UnZip)       :: _  ) => typeError(s"expected (!_*:_) but got: ${err.show}")
+      case ( err,         _, (_: Apply)       :: _  ) => typeError(s"expected (\\_._) but got ${err.show}")
+      case ( err,         _, (_: Evaluate)    :: _  ) => typeError(s"expected (^\\_._) but got ${err.show}")
 
     def step: State = (s: @unchecked) match
       case ( v @ Var(x),          Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
       case ( App(t,m),            e,                 ks ) => (t, e, Apply(e,m)       :: ks)
       case ( Eval(t,m),           e,                 ks ) => (t, e, Evaluate(e,m)    :: ks)
-      case ( Fst(t),              e,                 ks ) => (t, e, Pi(e,0)          :: ks)
-      case ( Snd(t),              e,                 ks ) => (t, e, Pi(e,1)          :: ks)
+      case ( Fst(t),              e,                 ks ) => (t, e, Pi(0)            :: ks)
+      case ( Snd(t),              e,                 ks ) => (t, e, Pi(1)            :: ks)
       case ( CaseExpr(t,l,u,r,v), e,                 ks ) => (t, e, Sigma(e,l,u,r,v) :: ks)
-      case ( Let(x,t,u),          e,                 ks ) => (t, e, Bind(e,x,u)      :: ks)
+      case ( Let(x,t,u),          e,                 ks ) => (t, e, Effect(e,x,u)    :: ks)
       case ( LetT(x,y,t,u),       e,                 ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
 
   @tailrec
@@ -78,8 +74,8 @@ object Kernel:
       run(state.step, debug)
   end run
 
-  private def bind(env: Environment, bindings: (Name, ErasedTree)*): Environment =
-    bindings.foldRight(env)((p, env) => if p.head == "_" then env else Closure(p(0), p(1), Nil)::env)
+  private def bind(env: Environment, outer: Environment, bindings: (Name, ErasedTree)*): Environment =
+    bindings.foldRight(env)((p, env) => if p.head == "_" then env else Closure(p(0), p(1), outer)::env)
 
   object Redex:
     def unapply(redex:
@@ -108,5 +104,6 @@ object Kernel:
   def eval[T](t: Tree[T], debug: Boolean = false): Either[TypeError, T] =
     reduce(t, debug).flatMap {
       case Pure(t) => Right(t)
+      case Point   => Right(())
       case term    => Left(TypeError(s"Program terminated with ${term.show}"))
     }

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -10,11 +10,12 @@ final class TypeError(msg: String) extends RuntimeException(msg)
 object Kernel:
   import Continuation._
 
-  case class Closure(x: Name, t: ErasedTree, e: Environment)
+  case class Env(x: Name, t: ErasedTree, e: Environment)
+  case class Stp(x: Name, t: ErasedTree, e: Stoup)
 
   enum Continuation:
     case Apply(e: Environment, arg: ErasedTree)
-    case Evaluate(e: Environment, arg: ErasedTree)
+    case Evaluate(s: Stoup, e: Environment, arg: ErasedTree)
     case Pi(i: Int)
     case Sigma(e: Environment, inl: Name, l: ErasedTree, inr: Name, r: ErasedTree)
     case Effect(e: Environment, x: Name, u: ErasedTree)
@@ -22,12 +23,20 @@ object Kernel:
 
   given Show[Continuation] = { case p: Product => p.productPrefix.toLowerCase }
 
-  type Environment = List[Closure]
-  type State       = (ErasedTree, Environment, List[Continuation]) // TODO: add stoup with correct semantics
+  type Environment = List[Env]
+  type Stoup       = Option[Stp]
+  type Constraint  = Boolean
+  type State       = (ErasedTree, Stoup, Environment, Constraint, List[Continuation])
+  final val Z      = None
+  final val C      = true
+  final val V      = false
 
-  private inline def (s: State).continuation: List[Continuation] = s(2)
+  private inline def (s: State).continuation: List[Continuation] = s(4)
 
-  given (given m: Mirror.ProductOf[Closure], rec: => Show[m.MirroredElemTypes]): Show[Closure] =
+  given (given m: Mirror.ProductOf[Env], rec: => Show[m.MirroredElemTypes]): Show[Env] =
+    Tuple.fromProductTyped(_).show
+
+  given (given m: Mirror.ProductOf[Stp], rec: => Show[m.MirroredElemTypes]): Show[Stp] =
     Tuple.fromProductTyped(_).show
 
   private def typeError(msg: String): Nothing = throw TypeError(msg)
@@ -35,31 +44,38 @@ object Kernel:
   private extension on (s: State):
 
     def betaReduce: State = (s: @unchecked) match
-      case ( Pair(x,_),   e, Pi(0)            :: ks ) => ( x, e,                      ks )
-      case ( Pair(_,y),   e, Pi(1)            :: ks ) => ( y, e,                      ks )
-      case ( Inl(t),      e, Sigma(f,l,u,_,_) :: ks ) => ( u, bind(f,e,l->t),         ks )
-      case ( Inr(t),      e, Sigma(f,_,_,r,u) :: ks ) => ( u, bind(f,e,r->t),         ks )
-      case ( t @ Lazy(_), e, Effect(f,x,u)    :: ks ) => ( u, bind(f,e,x->t.compute), ks )
-      case ( Bang(t),     e, Effect(f,x,u)    :: ks ) => ( u, bind(f,e,x->t),         ks )
-      case ( Tensor(t,s), e, UnZip(f,x,y,u)   :: ks ) => ( u, bind(f,e,x->t,y->s),    ks )
-      case ( Lam(x,t),    e, Apply(f,m)       :: ks ) => ( t, bind(e,f,x->m),         ks )
-      case ( Lin(x,t),    e, Evaluate(f,m)    :: ks ) => ( t, bind(e,f,x->m),         ks )
-      case ( err,         _, (_: Pi)          :: _  ) => typeError(s"expected (_,_) but got: ${err.show}")
-      case ( err,         _, (_: Sigma)       :: _  ) => typeError(s"expected (inl _) or (inr _) but got: ${err.show}")
-      case ( err,         _, (_: Effect)      :: _  ) => typeError(s"expected (!_) but got: ${err.show}")
-      case ( err,         _, (_: UnZip)       :: _  ) => typeError(s"expected (!_*:_) but got: ${err.show}")
-      case ( err,         _, (_: Apply)       :: _  ) => typeError(s"expected (\\_._) but got ${err.show}")
-      case ( err,         _, (_: Evaluate)    :: _  ) => typeError(s"expected (^\\_._) but got ${err.show}")
+      case ( Pair(x,_),      s, e, d, Pi(0)            :: ks ) => ( x, s,           e,                     d, ks )
+      case ( Pair(_,y),      s, e, d, Pi(1)            :: ks ) => ( y, s,           e,                     d, ks )
+      case ( Inl(t),         s, e, d, Sigma(f,l,u,_,_) :: ks ) => ( u, s,           bind(f,e,l,t),         d, ks )
+      case ( Inr(t),         s, e, d, Sigma(f,_,_,r,u) :: ks ) => ( u, s,           bind(f,e,r,t),         d, ks )
+      case ( t @ Lazy(_),    s, e, C, Effect(f,x,u)    :: ks ) => ( u, Z,           bind(f,e,x,t.compute), C, ks )
+      case ( Bang(t),        Z, e, C, Effect(f,x,u)    :: ks ) => ( u, Z,           bind(f,e,x,t),         C, ks )
+      case ( Tensor(t,c),    s, e, C, UnZip(f,x,y,u)   :: ks ) => ( u, bind(s,y,c), bind(f,e,x,t),         C, ks )
+      case ( Lam(x,t),       s, e, d, Apply(f,m)       :: ks ) => ( t, s,           bind(e,f,x,m),         d, ks )
+      case ( Lin(x,t),       Z, _, V, Evaluate(s,f,m)  :: ks ) => ( t, bind(s,x,m), f,                     C, ks )
+      case ( err @ Bang(_),  _, _, _, (_: Effect)      :: _  ) => typeError(s"unexpected ${err.show} in linear context")
+      case ( err @ Lin(_,_), _, _, _, (_: Evaluate)    :: _  ) => typeError(s"unexpected ${err.show} in linear context")
+      case ( err,            _, _, _, (_: Pi)          :: _  ) => typeError(s"expected (_,_) but got: ${err.show}")
+      case ( err,            _, _, _, (_: Sigma)       :: _  ) => typeError(s"expected (inl _) or (inr _) but got: ${err.show}")
+      case ( err,            _, _, _, (_: Effect)      :: _  ) => typeError(s"expected (!_) but got: ${err.show}")
+      case ( err,            _, _, _, (_: UnZip)       :: _  ) => typeError(s"expected (!_*:_) but got: ${err.show}")
+      case ( err,            _, _, _, (_: Apply)       :: _  ) => typeError(s"expected (\\_._) but got ${err.show}")
+      case ( err,            _, _, _, (_: Evaluate)    :: _  ) => typeError(s"expected (^\\_._) but got ${err.show}")
 
     def step: State = (s: @unchecked) match
-      case ( v @ Var(x),          Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
-      case ( App(t,m),            e,                 ks ) => (t, e, Apply(e,m)       :: ks)
-      case ( Eval(t,m),           e,                 ks ) => (t, e, Evaluate(e,m)    :: ks)
-      case ( Fst(t),              e,                 ks ) => (t, e, Pi(0)            :: ks)
-      case ( Snd(t),              e,                 ks ) => (t, e, Pi(1)            :: ks)
-      case ( CaseExpr(t,l,u,r,v), e,                 ks ) => (t, e, Sigma(e,l,u,r,v) :: ks)
-      case ( Let(x,t,u),          e,                 ks ) => (t, e, Effect(e,x,u)    :: ks)
-      case ( LetT(x,y,t,u),       e,                 ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
+      case ( Var(x),              Some(Stp(y,n,f)), e,                  C, ks ) if x == y => ( n, f, e, C,                     ks )
+      case ( Var(x),              Z,                     Env(y,n,f)::_, V, ks ) if x == y => ( n, Z, f, V,                     ks )
+      case ( v @ Var(_),          Z,                     Env(_,_,_)::e, V, ks )           => ( v, Z, e, V,                     ks )
+      case ( App(t,m),            s,                     e,             d, ks )           => ( t, s, e, d, Apply(e,m)       :: ks )
+      case ( Eval(t,m),           s,                     e,             _, ks )           => ( t, s, e, V, Evaluate(s,e,m)  :: ks )
+      case ( Fst(t),              s,                     e,             d, ks )           => ( t, s, e, d, Pi(0)            :: ks )
+      case ( Snd(t),              s,                     e,             d, ks )           => ( t, s, e, d, Pi(1)            :: ks )
+      case ( CaseExpr(t,l,u,r,v), s,                     e,             d, ks )           => ( t, s, e, d, Sigma(e,l,u,r,v) :: ks )
+      case ( Let(x,t,u),          s,                     e,             _, ks )           => ( t, s, e, C, Effect(e,x,u)    :: ks )
+      case ( LetT(x,y,t,u),       s,                     e,             _, ks )           => ( t, s, e, C, UnZip(e,x,y,u)   :: ks )
+      case ( Var(x),              Some(_),               Env(y,n,_)::_, _, _  ) if x == y => typeError(s"Illegal reference to ${n.show} in linear context")
+      case ( Var(_),              Some(_),               _,             V, _  )           => typeError(s"evaluating linear value in pure context")
+      case ( Var(x),              Z,                     _,             C, _  )           => typeError(s"evaluating unbound value $x in computational context")
 
   @tailrec
   private def run(state: State, debug: Boolean): ErasedTree =
@@ -74,8 +90,11 @@ object Kernel:
       run(state.step, debug)
   end run
 
-  private def bind(env: Environment, outer: Environment, bindings: (Name, ErasedTree)*): Environment =
-    bindings.foldRight(env)((p, env) => if p.head == "_" then env else Closure(p(0), p(1), outer)::env)
+  private def bind(env: Environment, outer: Environment, name: Name, value: ErasedTree): Environment =
+    if name == "_" then env else Env(name, value, outer)::env
+
+  private def bind(outer: Stoup, name: Name, value: ErasedTree): Stoup =
+    Some(Stp(name, value, outer))
 
   object Redex:
     def unapply(redex:
@@ -93,12 +112,12 @@ object Kernel:
       | Point.type): true = true
 
   private def (s: State).redexOrFinal = s match
-  case (Redex(), _  , _ ) => true
-  case (Var(_) , Nil, _ ) => true
-  case _                  => false
+    case (Redex(), _,    _  , _, _ ) => true
+    case (Var(_),  None, Nil, _, _ ) => true
+    case _                           => false
 
   def reduce[T](t: Tree[T], debug: Boolean = false): Either[TypeError, Tree[T]] =
-    try Right(run(state = (t, Nil, Nil), debug).as)
+    try Right(run(state = (t, Z, Nil, V, Nil), debug).as)
     catch case e: TypeError => Left(e)
 
   def eval[T](t: Tree[T], debug: Boolean = false): Either[TypeError, T] =

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -3,142 +3,150 @@ package mesa.eec
 import Trees._, Tree._
 import deriving.Mirror
 import mesa.util.Show
+import annotation.tailrec
 
 final class TypeError(msg: String) extends RuntimeException(msg)
 
-object Kernel
+object Kernel:
+  import Continuation._
 
   case class Closure(x: Name, t: ErasedTree, e: Environment)
 
+  enum Continuation:
+    case Apply(e: Environment, arg: ErasedTree)
+    case Pi(e: Environment, i: Int)
+    case Sigma(e: Environment, inl: Name, l: ErasedTree, inr: Name, r: ErasedTree)
+    case Bind(e: Environment, x: Name, u: ErasedTree)
+    case Compute(e: Environment, x: Name, u: ErasedTree)
+    case UnZip(e: Environment, x: Name, y: Name, u: ErasedTree)
+    case ComputeLeft(e: Environment, x: Name, y: Name, yVal: ErasedTree, u: ErasedTree)
+
+  given Show[Continuation] = { case p: Product => p.productPrefix.toLowerCase }
+
   type Environment = List[Closure]
-  type State       = (ErasedTree, Environment, List[(ErasedTree, Environment)])
+  type State       = (ErasedTree, Environment, List[Continuation]) // TODO: add stoup with correct semantics
+
+  private inline def (s: State).continuation: List[Continuation] = s(2)
 
   given (given m: Mirror.ProductOf[Closure], rec: => Show[m.MirroredElemTypes]): Show[Closure] =
     Tuple.fromProductTyped(_).show
-
-  given Show[State] =
-    Show.t3
 
   private def start[T](t: Tree[T]): State = (t, Nil, Nil)
 
   private def typeError(msg: String): Nothing = throw TypeError(msg)
 
-  private def (s: State) step: State = (s: @unchecked) match
+  private extension on (s: State):
 
-  case ( v @ Var(x),       Closure(y,n,f)::e, s        ) => if x == y then (n,f,s) else (v,e,s)
-  case ( Lambda(x,t),      e,                 (m,f)::s ) => (t, Closure(x,m,f)::e, s       )
-  case ( Application(n,m), e,                 s        ) => (n, e,                 (m,e)::s)
+    def stepPi: State = (s: @unchecked) match
+    case ( Pair(x,_), _, Pi(e,0) :: ks ) => (x, e, ks)
+    case ( Pair(_,y), _, Pi(e,1) :: ks ) => (y, e, ks)
+    case ( err      , _, Pi(_,i) :: _  ) => typeError(s"expected (_,_) as argument to ${List("fst","snd")(i)} but got: ${err.show}")
+    end stepPi
 
-  case ( Project(p,i), e, s ) => rec(p, e, s) match
-    case p: Pair[a,b] => (if i == 0 then p._1 else p._2, e, s)
-    case v: Var[a]    => (Project(v.as, i), e, s)
-    case arg          => typeError(s"expected (_,_) as argument to ${List("fst","snd")(i)} but got: ${arg.show}")
+    def stepSigma: State = (s: @unchecked) match
+    case ( Application(Inl(), inl), _, Sigma(e,x,l,_,_) :: ks ) => (l, bind(e, x -> inl), ks)
+    case ( Application(Inr(), inr), _, Sigma(e,_,_,y,r) :: ks ) => (r, bind(e, y -> inr), ks)
+    case ( err                    , _, Sigma(_,_,_,_,_) :: _  ) => typeError(s"expected either (${Inl().show} _) or (${Inr().show} _) but got: ${err.show}")
+    end stepSigma
 
-  case ( CaseExpr(p,x,l,y,r), e, s ) => rec(p, e, s) match
-    case Application(Inl(), inl) => (l, bind(e, x -> rec(inl, e, s)), s)
-    case Application(Inr(), inr) => (r, bind(e, y -> rec(inr, e, s)), s)
-    case v: Var[a]               => (CaseExpr(v.as,x,l,y,r), e, s)
-    case arg                     => typeError(s"expected either (${Inl().show} _) or (${Inr().show} _) but got: ${arg.show}")
+    def stepBind: State = (s: @unchecked) match
+    case ( Application(Bang(), effect), e, Bind(f,x,u) :: ks ) => (effect, e, Compute(f,x,u) :: ks)
+    case ( err                        , _, Bind(_,_,_) :: _  ) => typeError(s"expected (!_) but got: ${err.show}")
+    end stepBind
 
-  case ( Let(x,t,u), e, s ) => rec(t, e, s) match
+    def stepCompute: State = (s: @unchecked) match
+    case ( Lazy(thunk), _, Compute(e,x,u) :: ks ) => (u, bind(e, x -> Pure(thunk())), ks)
+    case ( result     , _, Compute(e,x,u) :: ks ) => (u, bind(e, x -> result)       , ks)
+    end stepCompute
 
-    case Application(Bang(), effect) =>
-      val result = rec(effect, e, s) match
-        case Lazy(thunk) => Pure(thunk())
-        case result      => result
-      (u, bind(e, x -> result), s)
+    def stepUnZip: State = (s: @unchecked) match
+    case ( Tensor(effect, next), e, UnZip(f,x,y,u) :: ks ) => (effect, e, ComputeLeft(f,x,y,next,u) :: ks)
+    case ( err                 , _, UnZip(_,_,_,_) :: _  ) => typeError(s"expected (!_*:_) but got: ${err.show}")
+    end stepUnZip
 
-    case v: Var[a] => (Let(x,v.as,u), e, s)
-    case arg       => typeError(s"expected (! _) but got: ${arg.show}")
+    def stepComputeLeft: State = (s: @unchecked) match
+    case ( Lazy(thunk), _, ComputeLeft(e,x,y,next,u) :: ks ) => (u, bind(e, x -> Pure(thunk()), y -> next), ks)
+    case ( result     , _, ComputeLeft(e,x,y,next,u) :: ks ) => (u, bind(e, x -> result, y -> next)       , ks)
+    end stepComputeLeft
 
-  case ( LetT(x,y,t,u), e, s ) => rec(t, e, s) match
+    def stepApply: State = (s: @unchecked) match
+    case ( Lambda(x,t), e, Apply(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
+    case ( err        , _, Apply(_,m) :: ks ) => throw TypeError(s"Tried to apply non-function ${err.show} to ${m.show}")
+    end stepApply
 
-    case Tensor(effect, next) =>
-      val result = rec(effect, e, s) match
-        case Lazy(thunk) => Pure(thunk())
-        case result      => result
-      (u, bind(e, x -> result, y -> next), s)
+    def stepRoot: State = (s: @unchecked) match
+    case ( v @ Var(x)         , Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
+    case ( Application(n,m)   , e                , ks ) => (n, e, Apply(e,m)       :: ks)
+    case ( Project(p,i)       , e                , ks ) => (p, e, Pi(e,i)          :: ks)
+    case ( CaseExpr(p,x,l,y,r), e                , ks ) => (p, e, Sigma(e,x,l,y,r) :: ks)
+    case ( Let(x,t,u)         , e                , ks ) => (t, e, Bind(e,x,u)      :: ks)
+    case ( LetT(x,y,t,u)      , e                , ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
+    end stepRoot
 
-    case v: Var[a] => (LetT(x,y,v.as,u), e, s)
-    case arg       => typeError(s"expected (! _ *: _) but got: ${arg.show}")
-
-  end step
-
-  private def run(s: State): State =
-    println(s"step: ${s.show}")
-    if s.finalState then s
-    else run(step(s))
-
-  private def rec(s: State): ErasedTree =
-    run(s) match
-    case (t, Nil, (m,f)::_) => throw TypeError(s"Tried to apply non-function $t to $m")
-    case (t, _, _)          => t
+  @tailrec private def run(s: State): ErasedTree =
+    println(s"step: ${Show.show(s)}")
+    if s.finalState then s.continuation match
+      case (_: Pi)          :: _ => run(s.stepPi)
+      case (_: Apply)       :: _ => run(s.stepApply)
+      case (_: Sigma)       :: _ => run(s.stepSigma)
+      case (_: Bind)        :: _ => run(s.stepBind)
+      case (_: Compute)     :: _ => run(s.stepCompute)
+      case (_: UnZip)       :: _ => run(s.stepUnZip)
+      case (_: ComputeLeft) :: _ => run(s.stepComputeLeft)
+      case Nil                   => s.head
+    else
+      run(s.stepRoot)
+  end run
 
   private def bind(env: Environment, bindings: (Name, ErasedTree)*): Environment =
-    bindings.foldRight(env)((p, env) => Closure(p._1, p._2, Nil)::env)
+    bindings.foldRight(env)((p, env) => if p.head == "_" then env else Closure(p(0), p(1), Nil)::env)
 
-  object Opaque
+  object Opaque:
     def unapply(t: Pure[?] | Lazy[?] | Splice[?] | Point.type): true = true
 
-  object Effect
+  object Effect:
     def unapply(t: Inl[?,?] | Inr[?,?] | Bang[?] | WhyNot[?]): true = true
 
-  object Prod
+  object Prod:
     def unapply(t: Pair[?,?] | Tensor[?,?]): true = true
 
-  object Binder
+  object Binder:
     def unapply(t: Lin[?,?] | Lam[?,?]): true = true
 
-  object Lambda
+  object Lambda:
     def unapply(t: Lin[?,?] | Lam[?,?]): (Name, ErasedTree) = Tuple.fromProduct(t).asInstanceOf
 
-  object Application
-    def unapply[A,B](t: ErasedTree): Option[(ErasedTree, ErasedTree)] = t match
+  object Application:
+    def unapply(t: ErasedTree): Option[(ErasedTree, ErasedTree)] = t match
     case t: App[t,u]  => Some(Tuple.fromProductTyped(t))
     case t: Eval[t,u] => Some(Tuple.fromProductTyped(t))
     case _            => None
     end unapply
 
-  object Unreducible
-    def unapply(t: ErasedTree): Boolean = t match
-    case (
-      Project(Var(_), _)       // can't reduce a var
-    | Let(_,Var(_),_)          // can't reduce a var
-    | LetT(_,_,Var(_),_)       // can't reduce a var
-    | CaseExpr(Var(_),_,_,_,_) // can't reduce a var
-    | Var(_)                   // can't reduce a var
-    ) => true
-
-    case _ => false
-
-    end unapply
-
-  object Closed
+  object Closed:
     def unapply(t: ErasedTree): Boolean = t match
     case (
       Opaque()                 // has no dependency
     | Application(Effect(), _) // effects require an enclosing expression to evaluate
     | Prod()                   // products require an enclosing expression to project
+    | Binder()
     ) => true
-
     case _ => false
-
     end unapply
 
-  private def (s: State) finalState = s match
-  case (Binder()     , _  , Nil) => true
-  case (Unreducible(), Nil, _  ) => true
-  case (Closed()     , _  , _  ) => true
-  case _                         => false
+  private def (s: State).finalState = s match
+  case (Closed(), _  , _  ) => true
+  case (Var(_)  , Nil, _  ) => true
+  case _                    => false
   end finalState
 
-  private def [T](e: ErasedTree) as: Tree[T] = e.asInstanceOf[Tree[T]]
+  private def [T](e: ErasedTree).as: Tree[T] = e.asInstanceOf[Tree[T]]
 
   def run[T](t: Tree[T]): Unit =
     println(eval(t).merge)
 
   def reduce[T](t: Tree[T]): Either[TypeError, Tree[T]] =
-    try Right(rec(start(t)).as)
+    try Right(run(start(t)).as)
     catch case e: TypeError => Left(e)
 
   def eval[T](t: Tree[T]): Either[TypeError, T] =

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -14,6 +14,7 @@ object Kernel:
 
   enum Continuation:
     case Apply(e: Environment, arg: ErasedTree)
+    case Evaluate(e: Environment, arg: ErasedTree)
     case Pi(e: Environment, i: Int)
     case Sigma(e: Environment, inl: Name, l: ErasedTree, inr: Name, r: ErasedTree)
     case Bind(e: Environment, x: Name, u: ErasedTree)
@@ -31,8 +32,6 @@ object Kernel:
   given (given m: Mirror.ProductOf[Closure], rec: => Show[m.MirroredElemTypes]): Show[Closure] =
     Tuple.fromProductTyped(_).show
 
-  private def start[T](t: Tree[T]): State = (t, Nil, Nil)
-
   private def typeError(msg: String): Nothing = throw TypeError(msg)
 
   private extension on (s: State):
@@ -40,54 +39,61 @@ object Kernel:
     def stepPi: State = (s: @unchecked) match
     case ( Pair(x,_), _, Pi(e,0) :: ks ) => (x, e, ks)
     case ( Pair(_,y), _, Pi(e,1) :: ks ) => (y, e, ks)
-    case ( err      , _, Pi(_,i) :: _  ) => typeError(s"expected (_,_) as argument to ${List("fst","snd")(i)} but got: ${err.show}")
+    case ( err      , _, _             ) => typeError(s"expected (_,_) but got: ${err.show}")
 
     def stepSigma: State = (s: @unchecked) match
     case ( Inl(inl), _, Sigma(e,x,l,_,_) :: ks ) => (l, bind(e, x -> inl), ks)
     case ( Inr(inr), _, Sigma(e,_,_,y,r) :: ks ) => (r, bind(e, y -> inr), ks)
-    case ( err     , _, Sigma(_,_,_,_,_) :: _  ) => typeError(s"expected either (inl _) or (inr _) but got: ${err.show}")
+    case ( err     , _, _                      ) => typeError(s"expected either (inl _) or (inr _) but got: ${err.show}")
 
     def stepBind: State = (s: @unchecked) match
     case ( Bang(value), e, Bind(f,x,u) :: ks ) => (value, e                       , Reduce(f,x,u) :: ks)
     case ( l @ Lazy(_), e, Bind(f,x,u) :: ks ) => (u    , bind(e, x -> compute(l)), ks                 )
-    case ( err        , _, Bind(_,_,_) :: _  ) => typeError(s"expected (!_) but got: ${err.show}")
+    case ( err        , _, _                 ) => typeError(s"expected (!_) but got: ${err.show}")
 
     def stepReduce: State = (s: @unchecked) match
     case ( result, _, Reduce(e,x,u) :: ks ) => (u, bind(e, x -> result), ks)
 
     def stepUnZip: State = (s: @unchecked) match
     case ( Tensor(value, next), e, UnZip(f,x,y,u) :: ks ) => (value, e, ReduceLeft(f,x,y,next,u) :: ks)
-    case ( err                , _, UnZip(_,_,_,_) :: _  ) => typeError(s"expected (!_*:_) but got: ${err.show}")
+    case ( err                , _, _                    ) => typeError(s"expected (!_*:_) but got: ${err.show}")
 
     def stepReduceLeft: State = (s: @unchecked) match
     case ( result, _, ReduceLeft(e,x,y,next,u) :: ks ) => (u, bind(e, x -> result, y -> next) , ks)
 
     def stepApply: State = (s: @unchecked) match
-    case ( Lambda(x,t), e, Apply(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
-    case ( err        , _, Apply(_,m) :: ks ) => throw TypeError(s"Tried to apply non-function ${err.show} to ${m.show}")
+    case ( Lam(x,t), e, Apply(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
+    case ( err        , _, _             ) => typeError(s"expected (\\_._) but got ${err.show}")
+
+    def stepEvaluate: State = (s: @unchecked) match
+    case ( Lin(x,t), e, Evaluate(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
+    case ( err        , _, _                ) => typeError(s"expected (^\\_._) but got ${err.show}")
 
     def stepRoot: State = (s: @unchecked) match
     case ( v @ Var(x)         , Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
-    case ( Application(n,m)   , e                , ks ) => (n, e, Apply(e,m)       :: ks)
+    case ( App(n,m)           , e                , ks ) => (n, e, Apply(e,m)       :: ks)
+    case ( Eval(n,m)          , e                , ks ) => (n, e, Evaluate(e,m)    :: ks)
     case ( Project(p,i)       , e                , ks ) => (p, e, Pi(e,i)          :: ks)
     case ( CaseExpr(p,x,l,y,r), e                , ks ) => (p, e, Sigma(e,x,l,y,r) :: ks)
     case ( Let(x,t,u)         , e                , ks ) => (t, e, Bind(e,x,u)      :: ks)
     case ( LetT(x,y,t,u)      , e                , ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
     end stepRoot
 
-  @tailrec private def run(s: State): ErasedTree =
-    println(s"step: ${Show.show(s)}")
-    if s.finalState then s.continuation match
-      case (_: Pi)         :: _ => run(s.stepPi)
-      case (_: Apply)      :: _ => run(s.stepApply)
-      case (_: Sigma)      :: _ => run(s.stepSigma)
-      case (_: Bind)       :: _ => run(s.stepBind)
-      case (_: Reduce)     :: _ => run(s.stepReduce)
-      case (_: UnZip)      :: _ => run(s.stepUnZip)
-      case (_: ReduceLeft) :: _ => run(s.stepReduceLeft)
-      case Nil                  => s.head
+  @tailrec
+  private def run(state: State, debug: Boolean): ErasedTree =
+    if debug then println(s"step: ${Show.show(state)}")
+    if state.finalState then state.continuation match
+      case (_: Pi)         :: _ => run(state.stepPi, debug)
+      case (_: Apply)      :: _ => run(state.stepApply, debug)
+      case (_: Evaluate)   :: _ => run(state.stepEvaluate, debug)
+      case (_: Sigma)      :: _ => run(state.stepSigma, debug)
+      case (_: Bind)       :: _ => run(state.stepBind, debug)
+      case (_: Reduce)     :: _ => run(state.stepReduce, debug)
+      case (_: UnZip)      :: _ => run(state.stepUnZip, debug)
+      case (_: ReduceLeft) :: _ => run(state.stepReduceLeft, debug)
+      case Nil                  => state.head
     else
-      run(s.stepRoot)
+      run(state.stepRoot, debug)
   end run
 
   private def bind(env: Environment, bindings: (Name, ErasedTree)*): Environment =
@@ -98,51 +104,34 @@ object Kernel:
     case Fst(p) => (p, 0)
     case Snd(p) => (p, 1)
 
-  object Opaque:
+  object Opaque: // has no dependency
     def unapply(t: Pure[?] | Lazy[?] | Splice[?] | Point.type): true = true
 
-  object Effect:
+  object Effect: // effects require an enclosing expression to evaluate
     def unapply(t: Inl[?,?] | Inr[?,?] | Bang[?] | WhyNot[?]): true = true
 
-  object Prod:
+  object Prod: // products require an enclosing expression to project
     def unapply(t: Pair[?,?] | Tensor[?,?]): true = true
 
-  object Binder:
+  object Binder: // binder requires enclosing application to reduce
     def unapply(t: Lin[?,?] | Lam[?,?]): true = true
-
-  object Lambda:
-    def unapply(t: Lin[?,?] | Lam[?,?]): (Name, ErasedTree) = Tuple.fromProduct(t).asInstanceOf
-
-  object Application:
-    def unapply(t: ErasedTree): Option[(ErasedTree, ErasedTree)] = t match
-    case t: App[t,u]  => Some(Tuple.fromProductTyped(t))
-    case t: Eval[t,u] => Some(Tuple.fromProductTyped(t))
-    case _            => None
-    end unapply
 
   object Closed:
     def unapply(t: ErasedTree): Boolean = t match
-    case (
-      Opaque() // has no dependency
-    | Effect() // effects require an enclosing expression to evaluate
-    | Prod()   // products require an enclosing expression to project
-    | Binder() // binder requires enclosing application to reduce
-    ) => true
-    case _ => false
-    end unapply
+    case (Opaque() | Effect() | Prod() | Binder()) => true
+    case _                                         => false
 
   private def (s: State).finalState = s match
   case (Closed(), _  , _  ) => true
   case (Var(_)  , Nil, _  ) => true
   case _                    => false
-  end finalState
 
-  def reduce[T](t: Tree[T]): Either[TypeError, Tree[T]] =
-    try Right(run(start(t)).as)
+  def reduce[T](t: Tree[T], debug: Boolean = false): Either[TypeError, Tree[T]] =
+    try Right(run(state = (t, Nil, Nil), debug).as)
     catch case e: TypeError => Left(e)
 
-  def eval[T](t: Tree[T]): Either[TypeError, T] =
-    reduce(t).flatMap {
+  def eval[T](t: Tree[T], debug: Boolean = false): Either[TypeError, T] =
+    reduce(t, debug).flatMap {
       case Pure(t) => Right(t)
       case term    => Left(TypeError(s"Program terminated with ${term.show}"))
     }

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -1,0 +1,139 @@
+package mesa.eec
+
+import Trees._, Tree._
+import deriving.Mirror
+import mesa.util.Show
+
+final class TypeError(msg: String) extends RuntimeException(msg)
+
+object Kernel
+
+  case class Closure(x: Name, t: ErasedTree, e: Environment)
+
+  type Environment = List[Closure]
+  type State       = (ErasedTree, Environment, List[(ErasedTree, Environment)])
+
+  given (given m: Mirror.ProductOf[Closure], rec: => Show[m.MirroredElemTypes]): Show[Closure] =
+    Tuple.fromProductTyped(_).show
+
+  given Show[State] =
+    Show.t3
+
+  private def start[T](t: Tree[T]): State = (t, Nil, Nil)
+
+  private def typeError(msg: String): Nothing = throw TypeError(msg)
+
+  private def (s: State) step: State = (s: @unchecked) match
+
+  case ( v @ Var(x),       Closure(y,n,f)::e, s        ) => if x == y then (n,f,s) else (v,e,s)
+  case ( Lambda(x,t),      e,                 (m,f)::s ) => (t, Closure(x,m,f)::e, s       )
+  case ( Application(n,m), e,                 s        ) => (n, e,                 (m,e)::s)
+
+  case ( Project(p,i), e, s ) => rec(p, e, s) match
+    case p: Pair[a,b] => (if i == 0 then p._1 else p._2, e, s)
+    case v: Var[a]    => (Project(v.as, i), e, s)
+    case arg          => typeError(s"expected (_,_) as argument to ${List("fst","snd")(i)} but got: ${arg.show}")
+
+  case ( CaseExpr(p,x,l,y,r), e, s ) => rec(p, e, s) match
+    case Application(Inl(), inl) => (l, bind(e, x -> rec(inl, e, s)), s)
+    case Application(Inr(), inr) => (r, bind(e, y -> rec(inr, e, s)), s)
+    case v: Var[a]               => (CaseExpr(v.as,x,l,y,r), e, s)
+    case arg                     => typeError(s"expected either (${Inl().show} _) or (${Inr().show} _) but got: ${arg.show}")
+
+  case ( Let(x,t,u), e, s ) => rec(t, e, s) match
+
+    case Application(Bang(), effect) =>
+      val result = rec(effect, e, s) match
+        case Lazy(thunk) => Pure(thunk())
+        case result      => result
+      (u, bind(e, x -> result), s)
+
+    case v: Var[a] => (Let(x,v.as,u), e, s)
+    case arg       => typeError(s"expected (! _) but got: ${arg.show}")
+
+  case ( LetT(x,y,t,u), e, s ) => rec(t, e, s) match
+
+    case Tensor(effect, next) =>
+      val result = rec(effect, e, s) match
+        case Lazy(thunk) => Pure(thunk())
+        case result      => result
+      (u, bind(e, x -> result, y -> next), s)
+
+    case v: Var[a] => (LetT(x,y,v.as,u), e, s)
+    case arg       => typeError(s"expected (! _ *: _) but got: ${arg.show}")
+
+  end step
+
+  private def rec(s: State): ErasedTree =
+    println(s"step: ${s.show}")
+    if s.finalState then s._1
+    else rec(step(s))
+
+  private def bind(env: Environment, bindings: (Name, ErasedTree)*): Environment =
+    bindings.foldRight(env)((p, env) => Closure(p._1, p._2, Nil)::env)
+
+  object Opaque
+    def unapply(t: Pure[?] | Lazy[?] | Splice[?] | Point.type): true = true
+
+  object Effect
+    def unapply(t: Inl[?,?] | Inr[?,?] | Bang[?] | WhyNot[?]): true = true
+
+  object Prod
+    def unapply(t: Pair[?,?] | Tensor[?,?]): true = true
+
+  object Binder
+    def unapply(t: Lin[?,?] | Lam[?,?]): true = true
+
+  object Lambda
+    def unapply(t: Lin[?,?] | Lam[?,?]): (Name, ErasedTree) = Tuple.fromProduct(t).asInstanceOf
+
+  object Application
+    def unapply[A,B](t: ErasedTree): Option[(ErasedTree, ErasedTree)] = t match
+    case t: App[t,u]  => Some(Tuple.fromProductTyped(t))
+    case t: Eval[t,u] => Some(Tuple.fromProductTyped(t))
+    case _            => None
+    end unapply
+
+  object Unreducible
+    def unapply(t: ErasedTree): Boolean = t match
+    case (
+      Project(Var(_), _)       // can't reduce a var
+    | Let(_,Var(_),_)          // can't reduce a var
+    | LetT(_,_,Var(_),_)       // can't reduce a var
+    | CaseExpr(Var(_),_,_,_,_) // can't reduce a var
+    | Var(_)                   // can't reduce a var
+    ) => true
+
+    case _ => false
+
+    end unapply
+
+  object Closed
+    def unapply(t: ErasedTree): Boolean = t match
+    case (
+      Opaque()                 // has no dependency
+    | Application(Effect(), _) // effects require an enclosing expression to evaluate
+    | Prod()                   // products require an enclosing expression to project
+    ) => true
+
+    case _ => false
+
+    end unapply
+
+  private def (s: State) finalState = s match
+  case (Binder()     , _  , Nil) => true
+  case (Unreducible(), Nil, _  ) => true
+  case (Closed()     , _  , _  ) => true
+  case _                         => false
+  end finalState
+
+  private def [T](e: ErasedTree) as: Tree[T] = e.asInstanceOf[Tree[T]]
+
+  def run[T](t: Tree[T]): Unit =
+    println(compile(t).merge)
+
+  def compile[T](t: Tree[T]): Either[TypeError, T] =
+    try rec(start(t)) match
+      case Pure(t) => Right(t.asInstanceOf[T])
+      case term    => Left(TypeError(s"Program terminated with ${term.show}"))
+    catch case e: TypeError => Left(e)

--- a/eec-core/src/main/scala/mesa/eec/Kernel.scala
+++ b/eec-core/src/main/scala/mesa/eec/Kernel.scala
@@ -36,95 +36,70 @@ object Kernel:
 
   private extension on (s: State):
 
-    def stepPi: State = (s: @unchecked) match
-    case ( Pair(x,_), _, Pi(e,0) :: ks ) => (x, e, ks)
-    case ( Pair(_,y), _, Pi(e,1) :: ks ) => (y, e, ks)
-    case ( err      , _, _             ) => typeError(s"expected (_,_) but got: ${err.show}")
+    def betaReduce: State = (s: @unchecked) match
+      case ( Pair(x,_),   _, Pi(e,0)               :: ks ) => ( x, e, ks )
+      case ( Pair(_,y),   _, Pi(e,1)               :: ks ) => ( y, e, ks )
+      case ( Inl(t),      _, Sigma(e,l,u,_,_)      :: ks ) => ( u, bind(e,l->t), ks )
+      case ( Inr(t),      _, Sigma(e,_,_,r,u)      :: ks ) => ( u, bind(e,r->t), ks )
+      case ( t,           _, Reduce(e,x,u)         :: ks ) => ( u, bind(e,x->t), ks )
+      case ( t,           _, ReduceLeft(e,x,y,s,u) :: ks ) => ( u, bind(e,x->t,y->s), ks )
+      case ( t @ Lazy(_), _, Bind(e,x,u)           :: ks ) => ( u, bind(e,x->t.compute), ks )
+      case ( Bang(t),     e, Bind(f,x,u)           :: ks ) => ( t, e, Reduce(f,x,u)::ks )
+      case ( Tensor(t,s), e, UnZip(f,x,y,u)        :: ks ) => ( t, e, ReduceLeft(f,x,y,s,u)::ks )
+      case ( Lam(x,t),    e, Apply(f,m)            :: ks ) => ( t, Closure(x,m,f)::e, ks )
+      case ( Lin(x,t),    e, Evaluate(f,m)         :: ks ) => ( t, Closure(x,m,f)::e, ks )
+      case ( err,         _, (_: Pi)               :: ks ) => typeError(s"expected (_,_) but got: ${err.show}")
+      case ( err,         _, (_: Sigma)            :: ks ) => typeError(s"expected (inl _) or (inr _) but got: ${err.show}")
+      case ( err,         _, (_: Bind)             :: ks ) => typeError(s"expected (!_) but got: ${err.show}")
+      case ( err,         _, (_: UnZip)            :: ks ) => typeError(s"expected (!_*:_) but got: ${err.show}")
+      case ( err,         _, (_: Apply)            :: ks ) => typeError(s"expected (\\_._) but got ${err.show}")
+      case ( err,         _, (_: Evaluate)         :: ks ) => typeError(s"expected (^\\_._) but got ${err.show}")
 
-    def stepSigma: State = (s: @unchecked) match
-    case ( Inl(inl), _, Sigma(e,x,l,_,_) :: ks ) => (l, bind(e, x -> inl), ks)
-    case ( Inr(inr), _, Sigma(e,_,_,y,r) :: ks ) => (r, bind(e, y -> inr), ks)
-    case ( err     , _, _                      ) => typeError(s"expected either (inl _) or (inr _) but got: ${err.show}")
-
-    def stepBind: State = (s: @unchecked) match
-    case ( Bang(value), e, Bind(f,x,u) :: ks ) => (value, e                       , Reduce(f,x,u) :: ks)
-    case ( l @ Lazy(_), e, Bind(f,x,u) :: ks ) => (u    , bind(e, x -> compute(l)), ks                 )
-    case ( err        , _, _                 ) => typeError(s"expected (!_) but got: ${err.show}")
-
-    def stepReduce: State = (s: @unchecked) match
-    case ( result, _, Reduce(e,x,u) :: ks ) => (u, bind(e, x -> result), ks)
-
-    def stepUnZip: State = (s: @unchecked) match
-    case ( Tensor(value, next), e, UnZip(f,x,y,u) :: ks ) => (value, e, ReduceLeft(f,x,y,next,u) :: ks)
-    case ( err                , _, _                    ) => typeError(s"expected (!_*:_) but got: ${err.show}")
-
-    def stepReduceLeft: State = (s: @unchecked) match
-    case ( result, _, ReduceLeft(e,x,y,next,u) :: ks ) => (u, bind(e, x -> result, y -> next) , ks)
-
-    def stepApply: State = (s: @unchecked) match
-    case ( Lam(x,t), e, Apply(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
-    case ( err        , _, _             ) => typeError(s"expected (\\_._) but got ${err.show}")
-
-    def stepEvaluate: State = (s: @unchecked) match
-    case ( Lin(x,t), e, Evaluate(f,m) :: ks ) => (t, Closure(x,m,f)::e, ks )
-    case ( err        , _, _                ) => typeError(s"expected (^\\_._) but got ${err.show}")
-
-    def stepRoot: State = (s: @unchecked) match
-    case ( v @ Var(x)         , Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
-    case ( App(n,m)           , e                , ks ) => (n, e, Apply(e,m)       :: ks)
-    case ( Eval(n,m)          , e                , ks ) => (n, e, Evaluate(e,m)    :: ks)
-    case ( Project(p,i)       , e                , ks ) => (p, e, Pi(e,i)          :: ks)
-    case ( CaseExpr(p,x,l,y,r), e                , ks ) => (p, e, Sigma(e,x,l,y,r) :: ks)
-    case ( Let(x,t,u)         , e                , ks ) => (t, e, Bind(e,x,u)      :: ks)
-    case ( LetT(x,y,t,u)      , e                , ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
-    end stepRoot
+    def step: State = (s: @unchecked) match
+      case ( v @ Var(x),          Closure(y,n,f)::e, ks ) => if x == y then (n,f,ks) else (v,e,ks)
+      case ( App(t,m),            e,                 ks ) => (t, e, Apply(e,m)       :: ks)
+      case ( Eval(t,m),           e,                 ks ) => (t, e, Evaluate(e,m)    :: ks)
+      case ( Fst(t),              e,                 ks ) => (t, e, Pi(e,0)          :: ks)
+      case ( Snd(t),              e,                 ks ) => (t, e, Pi(e,1)          :: ks)
+      case ( CaseExpr(t,l,u,r,v), e,                 ks ) => (t, e, Sigma(e,l,u,r,v) :: ks)
+      case ( Let(x,t,u),          e,                 ks ) => (t, e, Bind(e,x,u)      :: ks)
+      case ( LetT(x,y,t,u),       e,                 ks ) => (t, e, UnZip(e,x,y,u)   :: ks)
 
   @tailrec
   private def run(state: State, debug: Boolean): ErasedTree =
-    if debug then println(s"step: ${Show.show(state)}")
-    if state.finalState then state.continuation match
-      case (_: Pi)         :: _ => run(state.stepPi, debug)
-      case (_: Apply)      :: _ => run(state.stepApply, debug)
-      case (_: Evaluate)   :: _ => run(state.stepEvaluate, debug)
-      case (_: Sigma)      :: _ => run(state.stepSigma, debug)
-      case (_: Bind)       :: _ => run(state.stepBind, debug)
-      case (_: Reduce)     :: _ => run(state.stepReduce, debug)
-      case (_: UnZip)      :: _ => run(state.stepUnZip, debug)
-      case (_: ReduceLeft) :: _ => run(state.stepReduceLeft, debug)
-      case Nil                  => state.head
+    if debug then
+      println(s"step: ${Show.show(state)}")
+    if state.redexOrFinal then
+      if state.continuation.isEmpty then
+        state.head
+      else
+        run(state.betaReduce, debug)
     else
-      run(state.stepRoot, debug)
+      run(state.step, debug)
   end run
 
   private def bind(env: Environment, bindings: (Name, ErasedTree)*): Environment =
     bindings.foldRight(env)((p, env) => if p.head == "_" then env else Closure(p(0), p(1), Nil)::env)
 
-  object Project:
-    def unapply(t: Fst[?,?] | Snd[?,?]): (ErasedTree, Int) = t match
-    case Fst(p) => (p, 0)
-    case Snd(p) => (p, 1)
+  object Redex:
+    def unapply(redex:
+        Pure[?]
+      | Splice[?]
+      | Lam[?,?]
+      | Lin[?,?]
+      | Inl[?,?]
+      | Inr[?,?]
+      | Bang[?]
+      | Lazy[?]
+      | WhyNot[?]
+      | Pair[?,?]
+      | Tensor[?,?]
+      | Point.type): true = true
 
-  object Opaque: // has no dependency
-    def unapply(t: Pure[?] | Lazy[?] | Splice[?] | Point.type): true = true
-
-  object Effect: // effects require an enclosing expression to evaluate
-    def unapply(t: Inl[?,?] | Inr[?,?] | Bang[?] | WhyNot[?]): true = true
-
-  object Prod: // products require an enclosing expression to project
-    def unapply(t: Pair[?,?] | Tensor[?,?]): true = true
-
-  object Binder: // binder requires enclosing application to reduce
-    def unapply(t: Lin[?,?] | Lam[?,?]): true = true
-
-  object Closed:
-    def unapply(t: ErasedTree): Boolean = t match
-    case (Opaque() | Effect() | Prod() | Binder()) => true
-    case _                                         => false
-
-  private def (s: State).finalState = s match
-  case (Closed(), _  , _  ) => true
-  case (Var(_)  , Nil, _  ) => true
-  case _                    => false
+  private def (s: State).redexOrFinal = s match
+  case (Redex(), _  , _ ) => true
+  case (Var(_) , Nil, _ ) => true
+  case _                  => false
 
   def reduce[T](t: Tree[T], debug: Boolean = false): Either[TypeError, Tree[T]] =
     try Right(run(state = (t, Nil, Nil), debug).as)

--- a/eec-core/src/main/scala/mesa/eec/Macros.scala
+++ b/eec-core/src/main/scala/mesa/eec/Macros.scala
@@ -30,8 +30,7 @@ object Macros {
         case Project(_, e) =>
           (stack: @unchecked) match
           case '{ $p1: Tree[$t1] } :: s1 =>
-            val e1: Expr[Int & Singleton] = Expr(e)
-            '{Project[Any,Any,Int & Singleton]($p1.asInstanceOf[Tree[(Any, Any)]], $e1)} :: s1
+            '{Project($p1.asInstanceOf[Tree[(Any, Any)]], ${Expr(e: Int & Singleton)}).asInstanceOf[Tree[Any]]} :: s1
 
         case App(_,_) =>
           (stack: @unchecked) match

--- a/eec-core/src/main/scala/mesa/eec/Macros.scala
+++ b/eec-core/src/main/scala/mesa/eec/Macros.scala
@@ -27,20 +27,45 @@ object Macros {
           case '{ $a1: Tree[$t1] } :: '{ $b1: Tree[$t2] } :: s1 =>
             '{Tensor[$t1, $t2]($a1, $b1)}::s1
 
-        case Project(_, e) =>
+        case Fst(_) =>
           (stack: @unchecked) match
           case '{ $p1: Tree[$t1] } :: s1 =>
-            '{Project($p1.asInstanceOf[Tree[(Any, Any)]], ${Expr(e: Int & Singleton)}).asInstanceOf[Tree[Any]]} :: s1
+            '{Fst($p1.asInstanceOf[Tree[(Any, Any)]])} :: s1
+
+        case Snd(_) =>
+          (stack: @unchecked) match
+          case '{ $p1: Tree[$t1] } :: s1 =>
+            '{Snd($p1.asInstanceOf[Tree[(Any, Any)]])} :: s1
+
+        case Bang(_) =>
+          (stack: @unchecked) match
+          case '{ $a1: Tree[$t1] } :: s1 =>
+            '{Bang($a1)} :: s1
+
+        case WhyNot(_) =>
+          (stack: @unchecked) match
+          case '{ $v1: Tree[$t1] } :: s1 =>
+            '{WhyNot($v1.asInstanceOf[Tree[Nothing]])} :: s1
+
+        case Inl(_) =>
+          (stack: @unchecked) match
+          case '{ $a1: Tree[$t1] } :: s1 =>
+            '{Inl[$t1, Any]($a1)} :: s1
+
+        case Inr(_) =>
+          (stack: @unchecked) match
+          case '{ $a1: Tree[$t1] } :: s1 =>
+            '{Inr[Any, $t1]($a1)} :: s1
 
         case App(_,_) =>
           (stack: @unchecked) match
           case '{ $f1: Tree[$t1] } :: '{ $x1: Tree[$t2] } :: s1 =>
-            '{App($f1.asInstanceOf[Tree[Any => Any]], $x1.asInstanceOf[Tree[Any]])} :: s1
+            '{App($f1.asInstanceOf[Tree[$t2 => Any]], $x1)} :: s1
 
         case Eval(_,_) =>
           (stack: @unchecked) match
           case '{ $f1: Tree[$t1] } :: '{ $x1: Tree[$t2] } :: s1 =>
-            '{Eval($f1.asInstanceOf[Tree[Any => Any]], $x1.asInstanceOf[Tree[Any]])} :: s1
+            '{Eval($f1.asInstanceOf[Tree[$t2 => Any]], $x1)} :: s1
 
         case Lam(x1,_) =>
           (stack: @unchecked) match
@@ -68,10 +93,6 @@ object Macros {
             '{LetT(${Expr(x)}, ${Expr(z)}, $a1.asInstanceOf[Tree[(Any, Any)]], $b1)} :: s1
 
         case Point     => '{Point}                  :: stack
-        case Bang()    => '{Bang()}                 :: stack
-        case WhyNot()  => '{WhyNot()}               :: stack
-        case Inl()     => '{Inl()}                  :: stack
-        case Inr()     => '{Inr()}                  :: stack
         case Splice(n) => '{Lazy(() => ${args(n)})} :: stack
         case Var(x)    => '{Var(${Expr(x)})}        :: stack
         case Pure(x)   =>  { qctx.error(s"Access to value $x from wrong staging level"); ??? }

--- a/eec-core/src/main/scala/mesa/eec/Macros.scala
+++ b/eec-core/src/main/scala/mesa/eec/Macros.scala
@@ -118,11 +118,15 @@ object Macros {
     ((scExpr, argsExpr): @unchecked) match {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         val code = encode(parts)
-        parseAll(term[Any], StringReader(code)) match {
-          case Success(matched,_) => reifyErased(matched, args)
-          case f:Failure          => sys.error(f.toString)
-          case e:Error            => sys.error(e.toString)
-        }
+        val reader = StringReader(code)
+        try
+          parseAll(term[Any], reader) match {
+            case Success(matched,_) => reifyErased(matched, args)
+            case f:Failure          => sys.error(f.toString)
+            case e:Error            => sys.error(e.toString)
+          }
+        finally
+          reader.close()
     }
   }
 }

--- a/eec-core/src/main/scala/mesa/eec/Macros.scala
+++ b/eec-core/src/main/scala/mesa/eec/Macros.scala
@@ -12,14 +12,14 @@ import Trees.Tree
 import Tree._
 
 object Macros {
-  def eecImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(given qctx: QuoteContext): Expr[Tree[?]] = {
+  def eecImpl(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]])(given qctx: QuoteContext): Expr[Tree[Any]] = {
 
-    def reify[U](t: Tree[U], args: Seq[Expr[Any]]): Expr[Tree[?]] = {
-      import qctx.tasty.{Tree => _, error => _, _, given}
+    def reifyErased[U: Type](t: Tree[U], args: Seq[Expr[Any]]): Expr[Tree[U]] = {
+      import qctx.tasty.{Tree => _, Singleton => _, error => _, _, given}
       val expr = t.compile[Tree, U, Expr[Tree[?]]] {
         case Pair(_,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; $a1: Tree[`$t1`] } :: '{ type $t2; $b1: Tree[`$t2`] } :: s1 =>
+          case '{ $a1: Tree[$t1] } :: '{ $b1: Tree[$t2] } :: s1 =>
             '{Pair[$t1, $t2]($a1, $b1)}::s1
 
         case Tensor(_,_) =>
@@ -27,92 +27,58 @@ object Macros {
           case '{ $a1: Tree[$t1] } :: '{ $b1: Tree[$t2] } :: s1 =>
             '{Tensor[$t1, $t2]($a1, $b1)}::s1
 
+        case Project(_, e) =>
+          (stack: @unchecked) match
+          case '{ $p1: Tree[$t1] } :: s1 =>
+            val e1: Expr[Int & Singleton] = Expr(e)
+            '{Project[Any,Any,Int & Singleton]($p1.asInstanceOf[Tree[(Any, Any)]], $e1)} :: s1
+
         case App(_,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; type $t2; $f1: Tree[`$t1` => `$t2`] } :: s1 =>
-            (s1: @unchecked) match
-            case '{ type $t3; $x1: Tree[`$t3`] } :: s2 =>
-              if typeOf[$t3] <:< typeOf[$t1]
-                '{App($f1, $x1.asInstanceOf[Tree[$t1]])}::s2
-              else
-                qctx.error(s"cannot apply argument of ${t3.show} to parameter of type ${t1.show}")
-                Nil
-          case '{ type $t1; $f1: Tree[`$t1`] }::_ =>
-            qctx.error(s"cannot apply to non-function type ${t1.show}")
-            Nil
+          case '{ $f1: Tree[$t1] } :: '{ $x1: Tree[$t2] } :: s1 =>
+            '{App($f1.asInstanceOf[Tree[Any => Any]], $x1.asInstanceOf[Tree[Any]])} :: s1
 
         case Eval(_,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; type $t2; $f1: Tree[`$t1` => `$t2`] } :: s1 =>
-            (s1: @unchecked) match
-            case '{ type $t3; $x1: Tree[`$t3`] } :: s2 =>
-              if typeOf[$t3] <:< typeOf[$t1]
-                '{Eval($f1, $x1.asInstanceOf[Tree[$t1]])}::s2
-              else
-                qctx.error(s"cannot apply argument of ${t3.show} to parameter of type ${t1.show}")
-                Nil
-          case '{ type $t1; $f1: Tree[`$t1`] }::_ =>
-            qctx.error(s"cannot linearly evaluate non-function type ${t1.show}")
-            Nil
+          case '{ $f1: Tree[$t1] } :: '{ $x1: Tree[$t2] } :: s1 =>
+            '{Eval($f1.asInstanceOf[Tree[Any => Any]], $x1.asInstanceOf[Tree[Any]])} :: s1
 
         case Lam(x1,_) =>
           (stack: @unchecked) match
           case '{ type $t1; $a1: Tree[`$t1`] } :: s1 =>
-            '{Lam(${Expr(x1)}, $a1)}::s1
+            '{Lam(${Expr(x1)}, $a1)} :: s1
 
         case Lin(x1,_) =>
           (stack: @unchecked) match
           case '{ type $t1; $a1: Tree[`$t1`] } :: s1 =>
-            '{Lin(${Expr(x1)}, $a1)}::s1
+            '{Lin(${Expr(x1)}, $a1)} :: s1
 
         case CaseExpr(_,x,_,y,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; type $t2; $e1: Tree[Either[`$t1`, `$t2`]] } :: s1 =>
-            (s1: @unchecked) match
-            case '{ type $t3; $l1: Tree[`$t3`] } :: s2 =>
-              (s2: @unchecked) match
-              case '{ $r1: Tree[`$t3`] } :: s3 =>
-                '{CaseExpr($e1, ${Expr(x)}, $l1, ${Expr(y)}, $r1)}::s1
-              case _::_ =>
-                qctx.error(s"body of case inr $y does not match case inl $x")
-                Nil
-          case '{ type $t1; $e1: Tree[`$t1`] } :: _ =>
-            qctx.error(s"selector is not Either[?,?], but ${t1.show}")
-            Nil
+          case '{ $e1: Tree[$t1] } :: '{ $l1: Tree[$t2] } :: '{ $r1: Tree[$t3] } :: s1 =>
+            '{CaseExpr($e1.asInstanceOf[Tree[Either[Any,Any]]], ${Expr(x)}, $l1.asInstanceOf[Tree[Any]], ${Expr(y)}, $r1.asInstanceOf[Tree[Any]])} :: s1
 
         case Let(x,_,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; $a1: Tree[`$t1`] } :: '{ type $t2; $b1: Tree[`$t2`] } :: s1 =>
-            '{Let(${Expr(x)}, $a1, $b1)}::s1
+          case '{ $a1: Tree[$t1] } :: '{ $b1: Tree[$t2] } :: s1 =>
+            '{Let(${Expr(x)}, $a1, $b1)} :: s1
 
         case LetT(x,z,_,_) =>
           (stack: @unchecked) match
-          case '{ type $t1; type $t2; $a1: Tree[(`$t1`, `$t2`)] } :: '{ type $t3; $b1: Tree[`$t3`] } :: s1 =>
-            '{LetT(${Expr(x)}, ${Expr(z)}, $a1, $b1)}::s1
+          case '{ $a1: Tree[$t1] } :: '{ $b1: Tree[$t2] } :: s1 =>
+            '{LetT(${Expr(x)}, ${Expr(z)}, $a1.asInstanceOf[Tree[(Any, Any)]], $b1)} :: s1
 
-        case Bang(t) =>
-          (stack: @unchecked) match
-          case '{ type $t1; $a1: Tree[`$t1`] } :: s1 =>
-            '{Bang[$t1]($a1)}::s1
-
-        case WhyNot(t) =>
-          (stack: @unchecked) match
-          case '{ type $t1 <: Nothing; $a1: Tree[`$t1`] } :: s1 =>
-            '{WhyNot($a1)}::s1
-          case '{ type $t1; $a1: Tree[`$t1`] }::_ =>
-            qctx.error(s"cannot apply ${t1.show} to argument of Nothing type")
-            Nil
-
-        case Point     => '{Point} :: stack
-        case Fst()     => '{Fst()} :: stack
-        case Snd()     => '{Snd()} :: stack
-        case Inl()     => '{Inl()} :: stack
-        case Inr()     => '{Inr()} :: stack
-        case Splice(n) => '{lazy val x = ${args(n)}; Value(() => x)} :: stack
-        case Value(x)  =>  { qctx.tasty.error(s"access to value from wrong staging level", rootPosition); ??? }
-        case Var(x)    => '{Var(${Expr(x)})} :: stack
+        case Point     => '{Point}                  :: stack
+        case Bang()    => '{Bang()}                 :: stack
+        case WhyNot()  => '{WhyNot()}               :: stack
+        case Inl()     => '{Inl()}                  :: stack
+        case Inr()     => '{Inr()}                  :: stack
+        case Splice(n) => '{Lazy(() => ${args(n)})} :: stack
+        case Var(x)    => '{Var(${Expr(x)})}        :: stack
+        case Pure(x)   =>  { qctx.error(s"Access to value $x from wrong staging level"); ??? }
+        case Lazy(_)   =>  { qctx.error(s"Access to thunk from wrong staging level"); ??? }
       }
-      expr.cast[mesa.eec.Trees.Tree[?]]
+      expr.asInstanceOf[Expr[mesa.eec.Trees.Tree[U]]]
     }
 
     def encode(parts: Seq[Expr[String]])(given QuoteContext): String = {
@@ -140,7 +106,7 @@ object Macros {
       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
         val code = encode(parts)
         parseAll(term[Any], StringReader(code)) match {
-          case Success(matched,_) => reify(matched, args)
+          case Success(matched,_) => reifyErased(matched, args)
           case f:Failure          => sys.error(f.toString)
           case e:Error            => sys.error(e.toString)
         }

--- a/eec-core/src/main/scala/mesa/eec/Parsers.scala
+++ b/eec-core/src/main/scala/mesa/eec/Parsers.scala
@@ -18,18 +18,18 @@ object Parsers extends JavaTokenParsers {
 
   type P[T] = Parser[Tree[T]]
 
-  def term[T]: P[T]  = phrase(expr)
-  def expr[T]: P[T]  = app
+  def term[T] : P[T] = phrase(expr)
+  def expr[T] : P[T] = app
   def expr1[T]: P[T] = (lam | lin | let | letT | cse | expr2).asInstanceOf[P[T]]
   def expr2[T]: P[T] = (tsor | pExpr).asInstanceOf[P[T]]
   def pExpr[T]: P[T] = (bang | whyNot | fst | snd | inl | inr | eval | aexpr).asInstanceOf[P[T]]
   def aexpr[T]: P[T] = (ref | unit | pair | wrap | splice).asInstanceOf[P[T]]
 
-  def app[T]: P[T] = rep1(expr1)                     ^^ { case ts => ts.reduceLeft(((f: Tree[Any], a: Tree[Any]) => App[Any, Any](f.asInstanceOf[Tree[Any => Any]],a))).asInstanceOf[Tree[T]] }
+  def app[T]  : P[T]      = rep1(expr1)              ^^ { case ts => ts.reduceLeft(((f, a) => App(f.asInstanceOf[Tree[Any => Any]],a))).asInstanceOf[Tree[T]] }
   def lam[T,U]: P[T => U] = "\\"~>!id~!"."~!expr[U]  ^^ { case x~_~t => Lam(x,t) }
   def lin[T,U]: P[T => U] = "^\\"~>!id~!"."~!expr[U] ^^ { case x~_~t => Lin(x,t) }
 
-  def let[T,U]: P[U] = "let"~>"!"~>id~"be"~!expr~!"in"~!expr[U] ^^ {
+  def let[T,U]: P[U] = "let"~>"!"~>id~"be"~!expr[T]~!"in"~!expr[U] ^^ {
     case x~_~t~_~u => Let(x,t,u)
   }
 
@@ -44,20 +44,20 @@ object Parsers extends JavaTokenParsers {
     "}" ^^ { case e~_~_~_~x~_~l~_~_~y~_~r => CaseExpr(e,x,l,y,r) }
   }
 
-  def bang[T]: P[T]            = "!"   ~> aexpr[T]       ^^ { case e => Bang(e)      }
-  def whyNot[T]: P[T]          = "?"   ~> aexpr[Nothing] ^^ { case e => WhyNot(e)    }
-  def fst[A,B]: P[A]           = "fst" ~> aexpr[(A,B)]   ^^ { case e => App(Fst(),e) }
-  def snd[A,B]: P[B]           = "snd" ~> aexpr[(A,B)]   ^^ { case e => App(Snd(),e) }
-  def inl[A,B]: P[Either[A,B]] = "inl" ~> aexpr[A]       ^^ { case e => App(Inl(),e) }
-  def inr[A,B]: P[Either[A,B]] = "inr" ~> aexpr[B]       ^^ { case e => App(Inr(),e) }
+  def bang[T]  : P[T]           = "!"   ~> aexpr[T]       ^^ { case e => App(Bang(),e)   }
+  def whyNot[T]: P[T]           = "?"   ~> aexpr[Nothing] ^^ { case e => App(WhyNot(),e) }
+  def fst[A,B] : P[A]           = "fst" ~> aexpr[(A,B)]   ^^ { case e => Project(e, 0)   }
+  def snd[A,B] : P[B]           = "snd" ~> aexpr[(A,B)]   ^^ { case e => Project(e, 1)   }
+  def inl[A,B] : P[Either[A,B]] = "inl" ~> aexpr[A]       ^^ { case e => App(Inl(),e)    }
+  def inr[A,B] : P[Either[A,B]] = "inr" ~> aexpr[B]       ^^ { case e => App(Inr(),e)    }
 
-  def tsor[A,B]: P[(A,B)] = "!"~>aexpr[A]~"*:"~!aexpr[B]          ^^ { case t~_~z => Tensor(t,z)     }
-  def pair[A,B]: P[(A,B)] = "("~>expr[A]~","~!expr[B]<~!")"       ^^ { case t~_~u => Pair(t,u)       }
-  def eval[T,U]: P[U]     = aexpr[T => U] ~ "[" ~! expr[T] <~ "]" ^^ { case f~_~t => Eval(f,t)       }
-  def wrap[T]: P[T]       = "("~>expr[T]<~")"                     ^^ { x          => x               }
-  def unit: P[Unit]       = "*"                                   ^^ { _          => Point           }
-  def ref[T]:  P[T]       = id                                    ^^ {               Var(_)          }
-  def splice[T]           = HoleStart ~> HoleChar.*               ^^ { case cs  => Splice(cs.length) }
+  def tsor[A,B]: P[(A,B)] = "!"~>aexpr[A]~"*:"~!aexpr[B]          ^^ { case t~_~z => Tensor(t,z)       }
+  def pair[A,B]: P[(A,B)] = "("~>expr[A]~","~!expr[B]<~!")"       ^^ { case t~_~u => Pair(t,u)         }
+  def eval[T,U]: P[U]     = aexpr[T => U] ~ "[" ~! expr[T] <~ "]" ^^ { case f~_~t => Eval(f,t)         }
+  def wrap[T]  : P[T]     = "("~>expr[T]<~")"                     ^^ { x          => x                 }
+  def unit     : P[Unit]  = "*"                                   ^^ { _          => Point             }
+  def ref[T]   : P[T]     = id                                    ^^ { x          => Var(x)            }
+  def splice[T]: P[T]     = HoleStart ~> HoleChar.*               ^^ { case cs    => Splice(cs.length) }
 
   val reservedWords = Set(
     "case", "of", "let", "be", "in", "fst", "snd", "inl", "inr"

--- a/eec-core/src/main/scala/mesa/eec/Parsers.scala
+++ b/eec-core/src/main/scala/mesa/eec/Parsers.scala
@@ -44,12 +44,12 @@ object Parsers extends JavaTokenParsers {
     "}" ^^ { case e~_~_~_~x~_~l~_~_~y~_~r => CaseExpr(e,x,l,y,r) }
   }
 
-  def bang[T]  : P[T]           = "!"   ~> aexpr[T]       ^^ { case e => App(Bang(),e)   }
-  def whyNot[T]: P[T]           = "?"   ~> aexpr[Nothing] ^^ { case e => App(WhyNot(),e) }
-  def fst[A,B] : P[A]           = "fst" ~> aexpr[(A,B)]   ^^ { case e => Project(e, 0)   }
-  def snd[A,B] : P[B]           = "snd" ~> aexpr[(A,B)]   ^^ { case e => Project(e, 1)   }
-  def inl[A,B] : P[Either[A,B]] = "inl" ~> aexpr[A]       ^^ { case e => App(Inl(),e)    }
-  def inr[A,B] : P[Either[A,B]] = "inr" ~> aexpr[B]       ^^ { case e => App(Inr(),e)    }
+  def bang[T]  : P[T]           = "!"   ~> aexpr[T]       ^^ { case e => Bang(e)   }
+  def whyNot[T]: P[T]           = "?"   ~> aexpr[Nothing] ^^ { case e => WhyNot(e) }
+  def fst[A,B] : P[A]           = "fst" ~> aexpr[(A,B)]   ^^ { case e => Fst(e)    }
+  def snd[A,B] : P[B]           = "snd" ~> aexpr[(A,B)]   ^^ { case e => Snd(e)    }
+  def inl[A,B] : P[Either[A,B]] = "inl" ~> aexpr[A]       ^^ { case e => Inl(e)    }
+  def inr[A,B] : P[Either[A,B]] = "inr" ~> aexpr[B]       ^^ { case e => Inr(e)    }
 
   def tsor[A,B]: P[(A,B)] = "!"~>aexpr[A]~"*:"~!aexpr[B]          ^^ { case t~_~z => Tensor(t,z)       }
   def pair[A,B]: P[(A,B)] = "("~>expr[A]~","~!expr[B]<~!")"       ^^ { case t~_~u => Pair(t,u)         }

--- a/eec-core/src/main/scala/mesa/eec/Parsers.scala
+++ b/eec-core/src/main/scala/mesa/eec/Parsers.scala
@@ -30,7 +30,7 @@ object Parsers extends JavaTokenParsers {
   def lin[T,U]: P[T => U] = "^\\"~>!id~!"."~!expr[U]                     ^^ { case x~_~t     => Lin(x,t)   }
   def let[T,U]: P[U]      = "let"~>"!"~>pat~"be"~!expr[T]~!"in"~!expr[U] ^^ { case x~_~t~_~u => Let(x,t,u) }
 
-  def letT[T,U,V]: P[V] = "let"~>"!"~>pat~"&:"~!pat~!"be"~!expr[(T,U)]~!"in"~!expr[V] ^^ {
+  def letT[T,U,V]: P[V] = "let"~>"!"~>pat~"&:"~!id~!"be"~!expr[(T,U)]~!"in"~!expr[V] ^^ {
     case x~_~y~_~s~_~t => LetT(x,y,s,t)
   }
 

--- a/eec-core/src/main/scala/mesa/eec/Parsers.scala
+++ b/eec-core/src/main/scala/mesa/eec/Parsers.scala
@@ -30,7 +30,7 @@ object Parsers extends JavaTokenParsers {
   def lin[T,U]: P[T => U] = "^\\"~>!id~!"."~!expr[U]                     ^^ { case x~_~t     => Lin(x,t)   }
   def let[T,U]: P[U]      = "let"~>"!"~>pat~"be"~!expr[T]~!"in"~!expr[U] ^^ { case x~_~t~_~u => Let(x,t,u) }
 
-  def letT[T,U,V]: P[V] = "let"~>"!"~>pat~"*:"~!pat~!"be"~!expr[(T,U)]~!"in"~!expr[V] ^^ {
+  def letT[T,U,V]: P[V] = "let"~>"!"~>pat~"&:"~!pat~!"be"~!expr[(T,U)]~!"in"~!expr[V] ^^ {
     case x~_~y~_~s~_~t => LetT(x,y,s,t)
   }
 
@@ -48,11 +48,11 @@ object Parsers extends JavaTokenParsers {
   def inl[A,B] : P[Either[A,B]] = "inl" ~> aexpr[A]       ^^ { case e => Inl(e)    }
   def inr[A,B] : P[Either[A,B]] = "inr" ~> aexpr[B]       ^^ { case e => Inr(e)    }
 
-  def tsor[A,B]: P[(A,B)] = "!"~>aexpr[A]~"*:"~!aexpr[B]          ^^ { case t~_~z => Tensor(t,z)     }
+  def tsor[A,B]: P[(A,B)] = "!"~>aexpr[A]~"&:"~!aexpr[B]          ^^ { case t~_~z => Tensor(t,z)     }
   def pair[A,B]: P[(A,B)] = "("~>expr[A]~","~!expr[B]<~!")"       ^^ { case t~_~u => Pair(t,u)       }
   def eval[T,U]: P[U]     = aexpr[T => U] ~ "[" ~! expr[T] <~ "]" ^^ { case f~_~t => Eval(f,t)       }
   def wrap[T]  : P[T]     = "("~>expr[T]<~")"                     ^^ { x          => x               }
-  def unit     : P[Unit]  = "*"                                   ^^ { _          => Point           }
+  def unit     : P[Unit]  = "()"                                  ^^ { _          => Point           }
   def ref[T]   : P[T]     = id                                    ^^ { x          => Var(x)          }
   def splice[T]: P[T]     = "<"~>"""(0|[1-9]\d*)""".r<~">"        ^^ { d          => Splice(d.toInt) }
 

--- a/eec-core/src/main/scala/mesa/eec/Trees.scala
+++ b/eec-core/src/main/scala/mesa/eec/Trees.scala
@@ -3,6 +3,7 @@ package mesa.eec
 import mesa.util.StackMachine.{InterpretableK, Program, stack, Statement, Stack}
 import Program.compile
 import mesa.util.Show
+import runtime.ScalaRunTime.stringOf
 
 import annotation.tailrec
 
@@ -131,15 +132,15 @@ object Trees {
         val t1::u1::s1 = stack
         s"let !$x *: $z be $t1 in $u1"::s1
 
-      case Point     => "*"            :: stack
-      case Bang()    => "!"            :: stack
-      case WhyNot()  => "?"            :: stack
-      case Inl()     => "inl"          :: stack
-      case Inr()     => "inr"          :: stack
-      case Pure(x)   => s"%( $x )"     :: stack
-      case Lazy(_)   => s"{<thunk>}"   :: stack
-      case Splice(n) => s"<splice:$n>" :: stack
-      case Var(x)    => x              :: stack
+      case Point     => "*"                   :: stack
+      case Bang()    => "!"                   :: stack
+      case WhyNot()  => "?"                   :: stack
+      case Inl()     => "inl"                 :: stack
+      case Inr()     => "inr"                 :: stack
+      case Pure(x)   => s"~(${stringOf(x)})"  :: stack
+      case Lazy(_)   => s"~<thunk>"           :: stack
+      case Splice(n) => s"~<splice:$n>"       :: stack
+      case Var(x)    => x                     :: stack
 
     }
   }

--- a/eec-core/src/main/scala/mesa/eec/Trees.scala
+++ b/eec-core/src/main/scala/mesa/eec/Trees.scala
@@ -7,20 +7,15 @@ import runtime.ScalaRunTime.stringOf
 
 import annotation.tailrec
 
-object Trees {
+object Trees:
   import Tree._
 
-  type Name       = String
-  type ErasedTree = Tree[?]
+  type Name = String
 
-  type Pi[A, B, I <: Int] <: A | B = I match {
-    case 0 => A
-    case 1 => B
-    case _ => Nothing
-  }
+  private[eec] type ErasedTree = Tree[?]
+  private[eec] def [T](e: ErasedTree).as: Tree[T] = e.asInstanceOf[Tree[T]]
 
-  enum Tree[T] derives Eql {
-
+  enum Tree[T] derives Eql
     case Point                                                                              extends Tree[Unit]
     case Pair[A, B](a: Tree[A], b: Tree[B])                                                 extends Tree[(A,B)]
     case Tensor[A,B](t: Tree[A], z: Tree[B])                                                extends Tree[(A,B)]
@@ -38,19 +33,16 @@ object Trees {
     case WhyNot[T](t: Tree[Nothing])                                                        extends Tree[T]
     case Let[T,U](n: Name, t: Tree[T], u: Tree[U])                                          extends Tree[U]
     case LetT[A,B,U](x: Name, z: Name, s: Tree[(A,B)], t: Tree[U])                          extends Tree[U]
-    case Lazy[T](x: () => T)                                                                extends Tree[T]
+    case Lazy[T](op: () => T)                                                               extends Tree[T]
     case Pure[T](x: T)                                                                      extends Tree[T]
     case Splice[T](index: Int)                                                              extends Tree[T]
 
-  }
+  object Tree:
 
+    given InterpretableK[Tree]:
 
-  object Tree {
-
-    given InterpretableK[Tree] {
-      def [T,O](tree: Tree[T]) interpretK(z: O)(f: [t] => (O, Tree[t]) => O): O = {
-        @tailrec
-        def inner(z: O, ts: List[ErasedTree]): O = ts match {
+      def [T,O](tree: Tree[T]) interpretK(z: O)(f: [t] => (O, Tree[t]) => O): O =
+        @tailrec def inner(z: O, ts: List[ErasedTree]): O = ts match
           case Nil => z
           case t::ts => t match {
             case Pair(a,b)            => inner(f(z,t), a::b::ts)
@@ -70,100 +62,96 @@ object Trees {
             case LetT(_,_,e,u)        => inner(f(z,t), e::u::ts)
             case _                    => inner(f(z,t), ts)
           }
-        }
+        end inner
         inner(z, tree::Nil)
+      end interpretK
+    end given
+
+    given Show[ErasedTree] = summon[Show[Tree[Any]]].asInstanceOf[Show[ErasedTree]]
+
+    given [T]: Show[Tree[T]]:
+
+      def wrapIfComplex[U](t: Tree[U], s: String) = t match {
+        case Point | _:Var[?] | _:Pure[?] | _:Lazy[?] | _:Pair[?,?] => s
+        case _                                                      => s"($s)"
       }
-    }
-  }
 
-  given Show[ErasedTree] = summon[Show[Tree[Any]]].asInstanceOf[Show[ErasedTree]]
+      def wrapIfExpr1[U](t: Tree[U], s: String) = t match {
+        case _:Lam[?,?] | _:Lin[?,?] | _:Let[?,?] | _:LetT[?,?,?] | _:CaseExpr[?,?,?] => s"($s)"
+        case _                                                                        => s
+      }
 
-  given [T]: Show[Tree[T]] {
-    import Tree._
+      def (t: Tree[T]) show: String = t.compile[Tree, T, String] ({
 
-    def wrapIfComplex[U](t: Tree[U], s: String) = t match {
-      case Point | _:Var[?] | _:Pure[?] | _:Lazy[?] | _:Pair[?,?] => s
-      case _                                                      => s"($s)"
-    }
+        case Pair(a,b)  =>
+          val a1::b1::s1 = stack
+          s"($a1, $b1)"::s1
 
-    def wrapIfExpr1[U](t: Tree[U], s: String) = t match {
-      case _:Lam[?,?] | _:Lin[?,?] | _:Let[?,?] | _:LetT[?,?,?] | _:CaseExpr[?,?,?] => s"($s)"
-      case _                                                                        => s
-    }
+        case Tensor(v,z) =>
+          val v1::z1::s1 = stack
+          val v2 = wrapIfComplex(v,v1)
+          val z2 = wrapIfComplex(z,z1)
+          s"!$v2 *: $z2"::s1
 
-    def (t: Tree[T]) show: String = t.compile[Tree, T, String] {
+        case Fst(p) =>
+          val p1::s1 = stack
+          s"fst $p1"::s1
 
-      case Pair(a,b)  =>
-        val a1::b1::s1 = stack
-        s"($a1, $b1)"::s1
+        case Snd(p) =>
+          val p1::s1 = stack
+          s"snd $p1"::s1
 
-      case Tensor(v,z) =>
-        val v1::z1::s1 = stack
-        val v2 = wrapIfComplex(v,v1)
-        val z2 = wrapIfComplex(z,z1)
-        s"!$v2 *: $z2"::s1
+        case Bang(t) =>
+          val t1::s1 = stack
+          s"!$t1"::s1
 
-      case Fst(p) =>
-        val p1::s1 = stack
-        s"fst $p1"::s1
+        case WhyNot(v) =>
+          val v1::s1 = stack
+          s"?$v1"::s1
 
-      case Snd(p) =>
-        val p1::s1 = stack
-        s"snd $p1"::s1
+        case Inl(l) =>
+          val l1::s1 = stack
+          s"inl $l1"::s1
 
-      case Bang(t) =>
-        val t1::s1 = stack
-        s"!$t1"::s1
+        case Inr(r) =>
+          val r1::s1 = stack
+          s"inr $r1"::s1
 
-      case WhyNot(v) =>
-        val v1::s1 = stack
-        s"?$v1"::s1
+        case App(f,t) =>
+          val f1::t1::s1 = stack
+          val f2 = wrapIfExpr1(f,f1)
+          val t2 = wrapIfComplex(t,t1)
+          s"$f2 $t2"::s1
 
-      case Inl(l) =>
-        val l1::s1 = stack
-        s"inl $l1"::s1
+        case Eval(f,t) =>
+          val f1::t1::s1 = stack
+          val f2 = wrapIfExpr1(f, f1)
+          s"$f2[$t1]"::s1
 
-      case Inr(r) =>
-        val r1::s1 = stack
-        s"inr $r1"::s1
+        case Lam(x,t) =>
+          val t1::s1 = stack
+          s"\\$x.$t1"::s1
 
-      case App(f,t) =>
-        val f1::t1::s1 = stack
-        val f2 = wrapIfExpr1(f,f1)
-        val t2 = wrapIfComplex(t,t1)
-        s"$f2 $t2"::s1
+        case Lin(x,t) =>
+          val t1::s1 = stack
+          s"^\\$x.$t1"::s1
 
-      case Eval(f,t) =>
-        val f1::t1::s1 = stack
-        val f2 = wrapIfExpr1(f, f1)
-        s"$f2[$t1]"::s1
+        case CaseExpr(e,x,l,y,r) =>
+          val e1::l1::r1::s1 = stack
+          s"case $e1 of {inl $x.$l1; inr $y.$r1}"::s1
 
-      case Lam(x,t) =>
-        val t1::s1 = stack
-        s"\\$x.$t1"::s1
+        case Let(x,t,u) =>
+          val t1::u1::s1 = stack
+          s"let !$x be $t1 in $u1"::s1
 
-      case Lin(x,t) =>
-        val t1::s1 = stack
-        s"^\\$x.$t1"::s1
+        case LetT(x,z,t,u) =>
+          val t1::u1::s1 = stack
+          s"let !$x *: $z be $t1 in $u1"::s1
 
-      case CaseExpr(e,x,l,y,r) =>
-        val e1::l1::r1::s1 = stack
-        s"case $e1 of {inl $x.$l1; inr $y.$r1}"::s1
+        case Point     => "*"                  :: stack
+        case Pure(x)   => s"~(${stringOf(x)})" :: stack
+        case Lazy(_)   => s"~<thunk>"          :: stack
+        case Splice(n) => s"~<splice:$n>"      :: stack
+        case Var(x)    => x                    :: stack
 
-      case Let(x,t,u) =>
-        val t1::u1::s1 = stack
-        s"let !$x be $t1 in $u1"::s1
-
-      case LetT(x,z,t,u) =>
-        val t1::u1::s1 = stack
-        s"let !$x *: $z be $t1 in $u1"::s1
-
-      case Point     => "*"                   :: stack
-      case Pure(x)   => s"~(${stringOf(x)})"  :: stack
-      case Lazy(_)   => s"~<thunk>"           :: stack
-      case Splice(n) => s"~<splice:$n>"       :: stack
-      case Var(x)    => x                     :: stack
-
-    }
-  }
-}
+      })

--- a/eec-core/src/main/scala/mesa/eec/Trees.scala
+++ b/eec-core/src/main/scala/mesa/eec/Trees.scala
@@ -7,31 +7,39 @@ import mesa.util.Show
 import annotation.tailrec
 
 object Trees {
+  import Tree._
 
-  type Name = String
+  type Name       = String
+  type ErasedTree = Tree[?]
+
+  type Pi[A, B, I <: Int] <: A | B = I match {
+    case 0 => A
+    case 1 => B
+    case _ => Nothing
+  }
 
   enum Tree[T] derives Eql {
+
     case Point                                                                              extends Tree[Unit]
     case Pair[A, B](a: Tree[A], b: Tree[B])                                                 extends Tree[(A,B)]
+    case Tensor[A,B](t: Tree[A], z: Tree[B])                                                extends Tree[(A,B)]
     case Var[T](name: Name)                                                                 extends Tree[T]
     case App[T, U](f: Tree[T => U], t: Tree[T])                                             extends Tree[U]
     case Eval[T, U](f: Tree[T => U], t: Tree[T])                                            extends Tree[U]
     case Lam[T,U](x: Name, t: Tree[U])                                                      extends Tree[T => U]
     case Lin[T,U](x: Name, t: Tree[U])                                                      extends Tree[T => U]
     case CaseExpr[L, R, U](e: Tree[Either[L, R]], x: Name, l: Tree[U], y: Name, r: Tree[U]) extends Tree[U]
-    case Fst[A,B]()                                                                         extends Tree[((A, B)) => A]
-    case Snd[A,B]()                                                                         extends Tree[((A, B)) => B]
+    case Project[A,B,I <: Int & Singleton](p: Tree[(A,B)], elem: I)                         extends Tree[Pi[A,B,I]]
     case Inl[A,B]()                                                                         extends Tree[A => Either[A,B]]
     case Inr[A,B]()                                                                         extends Tree[B => Either[A,B]]
-    case Bang[T](t: Tree[T])                                                                extends Tree[T]
-    case WhyNot[T](e: Tree[Nothing])                                                        extends Tree[T]
-    case Tensor[A,B](t: Tree[A], z: Tree[B])                                                extends Tree[(A,B)]
+    case Bang[T]()                                                                          extends Tree[T => T]
+    case WhyNot[T]()                                                                        extends Tree[Nothing => T]
     case Let[T,U](n: Name, t: Tree[T], u: Tree[U])                                          extends Tree[U]
     case LetT[A,B,U](x: Name, z: Name, s: Tree[(A,B)], t: Tree[U])                          extends Tree[U]
-
-    /* These trees are for purposes of embedding Scala values in a tree */
-    case Value[T](x: () => T)                                                               extends Tree[T]
+    case Lazy[T](x: () => T)                                                                extends Tree[T]
+    case Pure[T](x: T)                                                                      extends Tree[T]
     case Splice[T](index: Int)                                                              extends Tree[T]
+
   }
 
 
@@ -44,14 +52,13 @@ object Trees {
           case Nil => z
           case t::ts => t match {
             case Pair(a,b)            => inner(f(z,t), a::b::ts)
+            case Tensor(v,u)          => inner(f(z,t), v::u::ts)
+            case Project(p, _)        => inner(f(z,t), p::ts)
             case App(g,u)             => inner(f(z,t), g::u::ts)
             case Eval(g,u)            => inner(f(z,t), g::u::ts)
             case Lam(_,u)             => inner(f(z,t), u::ts)
             case Lin(_,u)             => inner(f(z,t), u::ts)
             case CaseExpr(e,x,l,y,r)  => inner(f(z,t), e::l::r::ts)
-            case Bang(u)              => inner(f(z,t), u::ts)
-            case WhyNot(u)            => inner(f(z,t), u::ts)
-            case Tensor(v,u)          => inner(f(z,t), v::u::ts)
             case Let(_,e,u)           => inner(f(z,t), e::u::ts)
             case LetT(_,_,e,u)        => inner(f(z,t), e::u::ts)
             case _                    => inner(f(z,t), ts)
@@ -62,12 +69,14 @@ object Trees {
     }
   }
 
+  given Show[ErasedTree] = summon[Show[Tree[Any]]].asInstanceOf[Show[ErasedTree]]
+
   given [T]: Show[Tree[T]] {
     import Tree._
 
     def wrapIfComplex[U](t: Tree[U], s: String) = t match {
-      case Point | _:Var[?] | _:Value[?] | _:Pair[?,?] => s
-      case _                                         => s"($s)"
+      case Point | _:Var[?] | _:Pure[?] | _:Lazy[?] | _:Pair[?,?] => s
+      case _                                                      => s"($s)"
     }
 
     def wrapIfExpr1[U](t: Tree[U], s: String) = t match {
@@ -76,6 +85,7 @@ object Trees {
     }
 
     def (t: Tree[T]) show: String = t.compile[Tree, T, String] {
+
       case Pair(a,b)  =>
         val a1::b1::s1 = stack
         s"($a1, $b1)"::s1
@@ -85,6 +95,10 @@ object Trees {
         val v2 = wrapIfComplex(v,v1)
         val z2 = wrapIfComplex(z,z1)
         s"!$v2 *: $z2"::s1
+
+      case Project(p, e) =>
+        val p1::s1 = stack
+        s"${List("fst", "snd")(e)} $p1"::s1
 
       case App(f,t) =>
         val f1::t1::s1 = stack
@@ -117,24 +131,16 @@ object Trees {
         val t1::u1::s1 = stack
         s"let !$x *: $z be $t1 in $u1"::s1
 
-      case Bang(t) =>
-        val t1::s1 = stack
-        val t2 = wrapIfComplex(t,t1)
-        s"!$t2"::s1
-
-      case WhyNot(t) =>
-        val t1::s1 = stack
-        val t2 = wrapIfComplex(t,t1)
-        s"?$t2"::s1
-
-      case Point     => "*" :: stack
-      case Fst()     => "fst" :: stack
-      case Snd()     => "snd" :: stack
-      case Inl()     => "inl" :: stack
-      case Inr()     => "inr" :: stack
-      case Value(x)  => s"{| ${x().toString} |}" :: stack
+      case Point     => "*"            :: stack
+      case Bang()    => "!"            :: stack
+      case WhyNot()  => "?"            :: stack
+      case Inl()     => "inl"          :: stack
+      case Inr()     => "inr"          :: stack
+      case Pure(x)   => s"%( $x )"     :: stack
+      case Lazy(_)   => s"{<thunk>}"   :: stack
       case Splice(n) => s"<splice:$n>" :: stack
-      case Var(x)    => x :: stack
+      case Var(x)    => x              :: stack
+
     }
   }
 }

--- a/eec-core/src/main/scala/mesa/eec/eec.sc
+++ b/eec-core/src/main/scala/mesa/eec/eec.sc
@@ -6,23 +6,24 @@ def puts[A](a: A)(given Show[A]) =
 
 given Show[String] = identity
 
-puts(eec"*")
-puts(eec"""(\x.\y.y) (\x.y) *""")
-puts(eec"let !x *: z be s in inr z")
-puts(eec"let !y be x in *")
+puts(eec"()")
+puts(eec"""(\x.\y.y) (\x.y) ()""")
+puts(eec"let !x &: z be s in inr z")
+puts(eec"let !y be x in ()")
 puts(eec"!a")
 puts(eec"?v")
 puts(eec"a")
 puts(eec"!f g")
 puts(eec"!(f g)")
 puts(eec"fst (a, b)")
-puts(eec"snd (*, (a, b))")
-puts(eec"inl *")
-puts(eec"inr *")
-puts(eec"!a *: b")
-puts(eec"""!a *: ((\x.x) g)""")
+puts(eec"snd ((), (a, b))")
+puts(eec"inl ()")
+puts(eec"inr ()")
+puts(eec"(inr ()) ()")
+puts(eec"!a &: b")
+puts(eec"""!a &: ((\x.x) g)""")
 puts(eec"f (a b) (c d e)")
-puts(eec"""case inl z of {inl l.(\x.\y.*) a b; inr r.*}""")
+puts(eec"""case inl z of {inl l.(\x.\y.()) a b; inr r.()}""")
 puts(eec"""(\x.x) (\x.x)""")
 puts(eec"""(^\x.x)[${23}]""")
 
@@ -30,7 +31,7 @@ val I = eec"""\x.x"""
 val K = eec"""\x.\y.x"""
 val S = eec"""\f.\g.\x.f x (g x)"""
 
-val Bind = eec"""\f.\x.let !y be x in f y"""
+val Bind = eec"""\f.\t.let !x be t in f x"""
 
 puts(I)
 puts(K)

--- a/eec-core/src/main/scala/mesa/eec/package.scala
+++ b/eec-core/src/main/scala/mesa/eec/package.scala
@@ -5,6 +5,6 @@ import Trees.{Tree, ErasedTree}, Tree._
 
 inline def (inline sc: StringContext) eec (inline args: Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
 
-def compute[T](t: Lazy[T]): Tree[T] = succeed(t.op())
+def [T](t: Lazy[T]).compute: Tree[T] = succeed(t.op())
 def effect[T](op: => T): Tree[T]    = Lazy(() => op)
 def succeed[T](value: T): Tree[T]   = Pure(value)

--- a/eec-core/src/main/scala/mesa/eec/package.scala
+++ b/eec-core/src/main/scala/mesa/eec/package.scala
@@ -5,5 +5,6 @@ import Trees.{Tree, ErasedTree}, Tree._
 
 inline def (inline sc: StringContext) eec (inline args: Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
 
-def effect[T](op: => T) : Tree[T] = Bang(Lazy(() => op))
-def succeed[T](value: T): Tree[T] = Pure(value)
+def compute[T](t: Lazy[T]): Tree[T] = succeed(t.op())
+def effect[T](op: => T): Tree[T]    = Lazy(() => op)
+def succeed[T](value: T): Tree[T]   = Pure(value)

--- a/eec-core/src/main/scala/mesa/eec/package.scala
+++ b/eec-core/src/main/scala/mesa/eec/package.scala
@@ -1,5 +1,9 @@
 package mesa.eec
 
-import Trees.Tree
+import Trees.{Tree, ErasedTree}, Tree._
 
-inline def (sc: => StringContext) eec (args: => Any*) <: Tree[?] = ${ Macros.eecImpl('sc, 'args) }
+
+inline def (sc: => StringContext) eec (args: => Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
+
+def effect[T](op: => T) : Tree[T] = App(Bang(), Lazy(() => op))
+def succeed[T](value: T): Tree[T] = Pure(value)

--- a/eec-core/src/main/scala/mesa/eec/package.scala
+++ b/eec-core/src/main/scala/mesa/eec/package.scala
@@ -3,7 +3,7 @@ package mesa.eec
 import Trees.{Tree, ErasedTree}, Tree._
 
 
-inline def (sc: => StringContext) eec (args: => Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
+inline def (inline sc: StringContext) eec (inline args: Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
 
 def effect[T](op: => T) : Tree[T] = App(Bang(), Lazy(() => op))
 def succeed[T](value: T): Tree[T] = Pure(value)

--- a/eec-core/src/main/scala/mesa/eec/package.scala
+++ b/eec-core/src/main/scala/mesa/eec/package.scala
@@ -5,5 +5,5 @@ import Trees.{Tree, ErasedTree}, Tree._
 
 inline def (inline sc: StringContext) eec (inline args: Any*) <: ErasedTree = ${ Macros.eecImpl('sc, 'args) }
 
-def effect[T](op: => T) : Tree[T] = App(Bang(), Lazy(() => op))
+def effect[T](op: => T) : Tree[T] = Bang(Lazy(() => op))
 def succeed[T](value: T): Tree[T] = Pure(value)

--- a/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
+++ b/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
@@ -37,24 +37,24 @@ class InterpolatorTest
     assert(eec"""*""" == Point)
 
   @test def bang: Unit =
-    assert(eec"""!*""" == App(Bang(), Point))
+    assert(eec"""!*""" == Bang(Point))
 
   @test def bangSplice: Unit =
     var x = 0
     eec"""!${x = 1}""" match
-    case App(Bang(), Lazy(_)) =>
+    case Bang(Lazy(_)) =>
       assert(x == 0)
     case tree =>
       fail(s"bang with splice was $tree")
 
   @test def whyNot: Unit =
-    assert(eec"""?x""" == App(WhyNot(), Var("x")))
+    assert(eec"""?x""" == WhyNot(Var("x")))
 
   @test def inl: Unit =
-    assert(eec"""inl *""" == App(Inl(), Point))
+    assert(eec"""inl *""" == Inl(Point))
 
   @test def inr: Unit =
-    assert(eec"""inr *""" == App(Inr(), Point))
+    assert(eec"""inr *""" == Inr(Point))
 
   @test def caseexpr: Unit =
     assert(eec"""case x of {inl l.l; inr r.r}""" == CaseExpr(Var("x"), "l", Var("l"), "r", Var("r")))
@@ -66,7 +66,7 @@ class InterpolatorTest
     assert(eec"""let !x *: y be m in y""" == LetT("x", "y", Var("m"), Var("y")))
 
   @test def fst: Unit =
-    assert(eec"""fst x""" == Project(Var("x"), 0))
+    assert(eec"""fst x""" == Fst(Var("x")))
 
   @test def snd: Unit =
-    assert(eec"""snd x""" == Project(Var("x"), 1))
+    assert(eec"""snd x""" == Snd(Var("x")))

--- a/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
+++ b/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
@@ -31,13 +31,13 @@ class InterpolatorTest
     assert(eec"""(x,x)""" == Pair(Var("x"),Var("x")))
 
   @test def tensor: Unit =
-    assert(eec"""!x *: y""" == Tensor(Var("x"),Var("y")))
+    assert(eec"""!x &: y""" == Tensor(Var("x"),Var("y")))
 
   @test def point: Unit =
-    assert(eec"""*""" == Point)
+    assert(eec"""()""" == Point)
 
   @test def bang: Unit =
-    assert(eec"""!*""" == Bang(Point))
+    assert(eec"""!()""" == Bang(Point))
 
   @test def bangSplice: Unit =
     var x = 0
@@ -51,10 +51,10 @@ class InterpolatorTest
     assert(eec"""?x""" == WhyNot(Var("x")))
 
   @test def inl: Unit =
-    assert(eec"""inl *""" == Inl(Point))
+    assert(eec"""inl ()""" == Inl(Point))
 
   @test def inr: Unit =
-    assert(eec"""inr *""" == Inr(Point))
+    assert(eec"""inr ()""" == Inr(Point))
 
   @test def caseexpr: Unit =
     assert(eec"""case x of {inl l.l; inr r.r}""" == CaseExpr(Var("x"), "l", Var("l"), "r", Var("r")))
@@ -63,7 +63,7 @@ class InterpolatorTest
     assert(eec"""let !x be m in x""" == Let("x", Var("m"), Var("x")))
 
   @test def letT: Unit =
-    assert(eec"""let !x *: y be m in y""" == LetT("x", "y", Var("m"), Var("y")))
+    assert(eec"""let !x &: y be m in y""" == LetT("x", "y", Var("m"), Var("y")))
 
   @test def fst: Unit =
     assert(eec"""fst x""" == Fst(Var("x")))

--- a/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
+++ b/eec-core/src/test/scala/mesa/eec/InterpolatorTest.scala
@@ -1,0 +1,72 @@
+package mesa.eec
+
+import org.junit.Assert._
+import org.junit.{ Test => test }
+
+import Trees.Tree._
+
+class InterpolatorTest
+
+  @test def spliceIsLazy: Unit =
+    eec"${1}" match
+    case Lazy(t) => assert(t() == 1)
+    case tree    => fail(s"Splice was $tree")
+
+  @test def xIsVar: Unit =
+    assert(eec"x" == Var("x"))
+
+  @test def lambda1: Unit =
+    assert(eec"""\x.x""" == Lam("x", Var("x")))
+
+  @test def lambda2: Unit =
+    assert(eec"""^\x.x""" == Lin("x", Var("x")))
+
+  @test def app: Unit =
+    assert(eec"""(\x.x) Yes""" == App(Lam("x", Var("x")), Var("Yes")))
+
+  @test def eval: Unit =
+    assert(eec"""(^\x.x)[Yes]""" == Eval(Lin("x", Var("x")), Var("Yes")))
+
+  @test def pair: Unit =
+    assert(eec"""(x,x)""" == Pair(Var("x"),Var("x")))
+
+  @test def tensor: Unit =
+    assert(eec"""!x *: y""" == Tensor(Var("x"),Var("y")))
+
+  @test def point: Unit =
+    assert(eec"""*""" == Point)
+
+  @test def bang: Unit =
+    assert(eec"""!*""" == App(Bang(), Point))
+
+  @test def bangSplice: Unit =
+    var x = 0
+    eec"""!${x = 1}""" match
+    case App(Bang(), Lazy(_)) =>
+      assert(x == 0)
+    case tree =>
+      fail(s"bang with splice was $tree")
+
+  @test def whyNot: Unit =
+    assert(eec"""?x""" == App(WhyNot(), Var("x")))
+
+  @test def inl: Unit =
+    assert(eec"""inl *""" == App(Inl(), Point))
+
+  @test def inr: Unit =
+    assert(eec"""inr *""" == App(Inr(), Point))
+
+  @test def caseexpr: Unit =
+    assert(eec"""case x of {inl l.l; inr r.r}""" == CaseExpr(Var("x"), "l", Var("l"), "r", Var("r")))
+
+  @test def let: Unit =
+    assert(eec"""let !x be m in x""" == Let("x", Var("m"), Var("x")))
+
+  @test def letT: Unit =
+    assert(eec"""let !x *: y be m in y""" == LetT("x", "y", Var("m"), Var("y")))
+
+  @test def fst: Unit =
+    assert(eec"""fst x""" == Project(Var("x"), 0))
+
+  @test def snd: Unit =
+    assert(eec"""snd x""" == Project(Var("x"), 1))

--- a/eec-core/src/test/scala/mesa/eec/InterpreterTest.scala
+++ b/eec-core/src/test/scala/mesa/eec/InterpreterTest.scala
@@ -37,7 +37,7 @@ class InterpretorTest
   @test def letBangEvaluates: Unit =
     var x = 0
     val program = eec"""
-    let !x be !${x = 1; 99} in x
+    let !x be ${x = 1; 99} in x
     """
     Kernel.eval(program) match
     case Right(result) =>
@@ -59,20 +59,20 @@ class InterpretorTest
   @test def letTensorEvaluatesOnlyLeft: Unit =
     var xs = List.empty[Int]
     val program = eec"""
-    let !_ *: _ be !${xs ::= 0} *: (let !t be !${xs ::= 1} in *) in
+    let !_ *: _ be !No *: (let !t be !${xs ::= 0} in *) in
     *
     """
     Kernel.reduce(program) match
     case Right(res) =>
-      assert(xs == 0 :: Nil)
+      assert(xs == Nil)
       assert(res == eec"*")
     case Left(err) => throw err
 
-  @test def sequenceSideEffects: Unit =
+  @test def sequenceSideEffectsWithBang: Unit =
     var xs = List.empty[Int]
     val program = eec"""
-    let !x *: m be !${xs ::= 0; 35} *: (!${xs ::= 1}) in
-    let !_      be m                                  in
+    let !x be ${xs ::= 0; 35} in
+    let !_ be ${xs ::= 1}     in
     x
     """
     Kernel.eval(program) match
@@ -180,7 +180,7 @@ class InterpretorTest
   @test def nestedComputation: Unit =
     var xs = List.empty[Int]
     val program = eec"""
-    let !result be !((^\x.x)[let !m be !${xs ::= 0; 56} in m]) in
+    let !result be ((^\x.x)[let !m be ${xs ::= 0; 56} in !m]) in
     result
     """
     Kernel.eval(program) match
@@ -192,7 +192,7 @@ class InterpretorTest
   @test def caseExprReducesInl: Unit =
     var xs = List.empty[Int]
     val program = eec"""
-    case inl (let !t be !${xs ::= 0} in Yes) of { inl l.l; inr _.* }
+    case inl (let !t be ${xs ::= 0} in Yes) of { inl l.l; inr _.* }
     """
     Kernel.reduce(program) match
     case Right(term) =>
@@ -203,7 +203,7 @@ class InterpretorTest
   @test def caseExprReducesInr: Unit =
     var xs = List.empty[Int]
     val program = eec"""
-    case inr (let !t be !${xs ::= 0} in Yes) of { inl _.*; inr r.r }
+    case inr (let !t be ${xs ::= 0} in Yes) of { inl _.*; inr r.r }
     """
     Kernel.reduce(program) match
     case Right(term) =>

--- a/eec-core/src/test/scala/mesa/eec/InterpreterTest.scala
+++ b/eec-core/src/test/scala/mesa/eec/InterpreterTest.scala
@@ -1,0 +1,275 @@
+package mesa.eec
+
+import org.junit.Assert._
+import org.junit.{ Test => test }
+
+import Trees.Tree._
+
+class InterpretorTest
+
+  @test def spliceIsLazy: Unit =
+    var x = 0
+    val program = eec"${x == 1}"
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(x == 0)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def bangIsLazy: Unit =
+    var x = 0
+    val program = eec"!${x == 1}"
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(x == 0)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def whyNotIsLazy: Unit =
+    var x = 0
+    val program = eec"?${x == 1}"
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(x == 0)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def letBangEvaluates: Unit =
+    var x = 0
+    val program = eec"""
+    let !x be !${x = 1} in x
+    """
+    Kernel.reduce(program) match
+    case Right(res) =>
+      assert(x == 1)
+      assert(res == Pure(()))
+    case Left(err) =>
+      throw err
+
+  @test def tensorIsLazy: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    !(let !t be !${xs ::= 0} in No) *: (let !t be !${xs ::= 1} in No)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def letTensorEvaluatesOnlyLeft: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    let !_ *: _ be !${xs ::= 0} *: (let !t be !${xs ::= 1} in No) in
+    *
+    """
+    Kernel.reduce(program) match
+    case Right(res) =>
+      assert(xs == 0 :: Nil)
+      assert(res == eec"*")
+    case Left(err) =>
+      throw err
+
+  @test def sequenceSideEffects: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    let !_ *: m be !${xs ::= 0} *: (!${xs ::= 1}) in
+    let !_      be m                              in
+    Yes
+    """
+    Kernel.reduce(program) match
+    case Right(res) =>
+      assert(xs == 1 :: 0 :: Nil)
+      assert(res == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleVar: Unit =
+    val program = eec"""
+    No
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleFst: Unit =
+    val program = eec"""
+    fst No
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleSnd: Unit =
+    val program = eec"""
+    snd No
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleLet: Unit =
+    val program = eec"""
+    let !_ be No in *
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleLetT: Unit =
+    val program = eec"""
+    let !_ *: _ be No in *
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def haltUnreducibleCaseExpr: Unit =
+    val program = eec"""
+    case No of {inl _.*; inr _.*}
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def appReduceLambda: Unit =
+    val program = eec"""
+    (\x.x) Yes
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def evalReduceLinearLambda: Unit =
+    val program = eec"""
+    (^\x.x)[Yes]
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def pairIsLazy: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    (let !t be !${xs ::= 0} in No, let !t be !${xs ::= 1} in No)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def fstOnlyEvaluatesLeft: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    fst (Yes, let !x be !${xs ::= 0} in No)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def sndOnlyEvaluatesRight: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    snd (let !x be !${xs ::= 0} in No, Yes)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def inlIsLazy: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    inl (let !t be !${xs ::= 0} in No)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def inrIsLazy: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    inr (let !t be !${xs ::= 0} in No)
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == Nil)
+      assert(term == program)
+    case Left(err) =>
+      throw err
+
+  @test def caseExprReducesInl: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    case inl (let !t be !${xs ::= 0} in Yes) of { inl l.l; inr _.* }
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == 0 :: Nil)
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def caseExprReducesInr: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    case inr (let !t be !${xs ::= 0} in Yes) of { inl _.*; inr r.r }
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(xs == 0 :: Nil)
+      assert(term == eec"Yes")
+    case Left(err) =>
+      throw err
+
+  @test def inrIsNotBang: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    case inr ${xs ::= 0} of { inl _.*; inr r.r }
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(PartialFunction.cond(term) { case Lazy(_) => xs == Nil })
+    case Left(err) =>
+      throw err
+
+  @test def inlIsNotBang: Unit =
+    var xs = List.empty[Int]
+    val program = eec"""
+    case inl ${xs ::= 0} of { inl l.l; inr _.* }
+    """
+    Kernel.reduce(program) match
+    case Right(term) =>
+      assert(PartialFunction.cond(term) { case Lazy(_) => xs == Nil })
+    case Left(err) =>
+      throw err

--- a/mesa/src/main/scala/mesa/compiler/types/Typers.scala
+++ b/mesa/src/main/scala/mesa/compiler/types/Typers.scala
@@ -667,7 +667,7 @@ object Typers {
       if name == Name.Wildcard then {
         body1
       } else if mode == PatAlt then {
-        Err.nameInPattAlt(name)
+        Err.nameInPattAlt(name): Lifted[Tree] // TODO please report
       } else {
         putTermType(name -> body1.tpe)
         Bind(name, body1)(body1.tpe)

--- a/util/src/main/scala/mesa/util/Show.scala
+++ b/util/src/main/scala/mesa/util/Show.scala
@@ -11,12 +11,15 @@ object Show {
 
   given Show[String] = identity
 
-  given list[A](given Show[A]): Show[List[A]] =
+  given [A](given Show[A]): Show[List[A]] =
     _.map(_.show).mkString("[", ",", "]")
 
-  given t2[A,B](given Show[A], Show[B]): Show[(A,B)] =
+  given [A,B](given Show[A], Show[B]): Show[(A,B)] =
     (a,b) => s"(${a.show}, ${b.show})"
 
-  given t3[A,B,C](given Show[A], Show[B], Show[C]): Show[(A,B,C)] =
+  given [A,B,C](given Show[A], Show[B], Show[C]): Show[(A,B,C)] =
     (a,b,c) => s"(${a.show}, ${b.show}, ${c.show})"
+
+  given [A,B,C,D](given Show[A], Show[B], Show[C], Show[D]): Show[(A,B,C,D)] =
+    (a,b,c,d) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show})"
 }

--- a/util/src/main/scala/mesa/util/Show.scala
+++ b/util/src/main/scala/mesa/util/Show.scala
@@ -9,10 +9,14 @@ object Show {
 
   def show[T: Show](t: T): String = t.show
 
-  given Show[String] = identity
+  given Show[String]  = identity
+  given Show[Boolean] = _.toString
 
   given [A](given Show[A]): Show[List[A]] =
     _.map(_.show).mkString("[", ",", "]")
+
+  given [A](given Show[A]): Show[Option[A]] = opt =>
+    show(opt.map(_.show).toList)
 
   given [A,B](given Show[A], Show[B]): Show[(A,B)] =
     (a,b) => s"(${a.show}, ${b.show})"
@@ -22,4 +26,7 @@ object Show {
 
   given [A,B,C,D](given Show[A], Show[B], Show[C], Show[D]): Show[(A,B,C,D)] =
     (a,b,c,d) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show})"
+
+  given [A,B,C,D,E](given Show[A], Show[B], Show[C], Show[D], Show[E]): Show[(A,B,C,D,E)] =
+    (a,b,c,d,e) => s"(${a.show}, ${b.show}, ${c.show}, ${d.show}, ${e.show})"
 }

--- a/util/src/main/scala/mesa/util/Show.scala
+++ b/util/src/main/scala/mesa/util/Show.scala
@@ -1,6 +1,22 @@
 package mesa.util
 
 @FunctionalInterface
-trait Show[O] {
+trait Show[-O] {
   def (o: O) show: String
+}
+
+object Show {
+
+  def show[T: Show](t: T): String = t.show
+
+  given Show[String] = identity
+
+  given list[A](given Show[A]): Show[List[A]] =
+    _.map(_.show).mkString("[", ",", "]")
+
+  given t2[A,B](given Show[A], Show[B]): Show[(A,B)] =
+    (a,b) => s"(${a.show}, ${b.show})"
+
+  given t3[A,B,C](given Show[A], Show[B], Show[C]): Show[(A,B,C)] =
+    (a,b,c) => s"(${a.show}, ${b.show}, ${c.show})"
 }


### PR DESCRIPTION
This modifies the AST for the `mesa.eec` core language
- Add support for remembering the result of execution of an embedded Scala value, with the new Pure tree. Renamed Value to Lazy.
- removed type constraints from the reify macro

- Interpreter assumes untyped trees so has runtime checks for passed values, it also does not prevent consumption of a linear value more than once, however a well typed program should execute with the semantics described in the paper.

- A scala value is embedded lazily into an interpolated string, if wrapped with a Bang, then at a let expression, it will be evaluated and any side effects performed